### PR TITLE
feat(ohlcs): K线接口默认改为前复权，新增 None 不复权选项

### DIFF
--- a/FTShare-market-data/sub-skills/etf-ohlcs/SKILL.md
+++ b/FTShare-market-data/sub-skills/etf-ohlcs/SKILL.md
@@ -26,7 +26,7 @@ description: 单只 ETF OHLC K 线（market.ft.tech）。用户问某只 ETF 的
 | since | string | 是 | 起始日期 YYYYMMDD | 20240101 | - |
 | until | string | 否 | 结束日期 YYYYMMDD | 20240131 | 不传则默认今天 |
 | interval | string | 否 | K 线周期 | Day | Day（日线，默认）、Week（周线）、Month（月线）；无年线 |
-| adjust | string | 否 | 复权类型 | Forward | Forward（前复权）、Backward（后复权）；不传为不复权 |
+| adjust | string | 否 | 复权类型 | Forward | Forward（前复权，默认）、Backward（后复权）、None（不复权） |
 
 ## 3. 响应说明
 
@@ -71,6 +71,6 @@ python <RUN_PY> etf-ohlcs --etf 510050.XSHG --since 20230101 --interval Month --
 
 - `etf`、`since` 为必填；`since`/`until` 需为 YYYYMMDD（8 位数字）
 - `interval` 仅支持 Day/Week/Month（daec 无年线）；不传默认 Day
-- `adjust` 可选 Forward/Backward，不传为不复权（v2 不支持选复权，daec 为增强）
+- `adjust` 可选 Forward/Backward/None，默认 Forward（前复权）；None 为不复权（v2 不支持选复权，daec 为增强）
 - 执行方式：脚本将每条 `open_ts_ms`/`close_ts_ms`（毫秒）转为北京时间 ISO 字符串（YYYY-MM-DDTHH:mm:ss）
 - **已知问题**：daec 大区间响应（如多年日线，~100KB+）服务端偶发传输中断（IncompleteRead），脚本内置 5 次指数退避重试；如仍失败会非零退出。建议按需缩小日期区间

--- a/FTShare-market-data/sub-skills/etf-ohlcs/scripts/handler.py
+++ b/FTShare-market-data/sub-skills/etf-ohlcs/scripts/handler.py
@@ -51,7 +51,7 @@ def build_params(symbol: str, since: str, until: str, interval: str = "Day", adj
     if not _DATE_RE.match(until):
         raise ValueError(f"until 需为 YYYYMMDD（8 位数字）: {until!r}")
     params = {"symbol": symbol, "since": since, "until": until, "interval": interval}
-    if adjust is not None:
+    if adjust and adjust != "None":
         params["adjust"] = adjust
     return params
 
@@ -126,9 +126,9 @@ def main():
     )
     parser.add_argument(
         "--adjust",
-        default=None,
-        choices=["Forward", "Backward"],
-        help="复权类型：Forward（前复权）、Backward（后复权）；不传为不复权",
+        default="Forward",
+        choices=["Forward", "Backward", "None"],
+        help="复权类型：Forward（前复权，默认）、Backward（后复权）、None（不复权）",
     )
     args = parser.parse_args()
 

--- a/FTShare-market-data/sub-skills/index-ohlcs/SKILL.md
+++ b/FTShare-market-data/sub-skills/index-ohlcs/SKILL.md
@@ -26,7 +26,7 @@ description: 单只指数 OHLC K 线（market.ft.tech）。用户问某只指数
 | since | string | 是 | 起始日期 YYYYMMDD | 20240101 | - |
 | until | string | 否 | 结束日期 YYYYMMDD | 20240131 | 不传则默认今天 |
 | interval | string | 否 | K 线周期 | Day | Day（日线，默认）、Week（周线）、Month（月线）；无年线 |
-| adjust | string | 否 | 复权类型 | Forward | Forward（前复权）、Backward（后复权）；不传为不复权 |
+| adjust | string | 否 | 复权类型 | Forward | Forward（前复权，默认）、Backward（后复权）、None（不复权） |
 
 ## 3. 响应说明
 
@@ -71,6 +71,6 @@ python <RUN_PY> index-ohlcs --index 000001.XSHG --since 20230101 --interval Mont
 
 - `index`、`since` 为必填；`since`/`until` 需为 YYYYMMDD（8 位数字）
 - `interval` 仅支持 Day/Week/Month（daec 无年线）；不传默认 Day
-- `adjust` 可选 Forward/Backward，不传为不复权（v2 不支持选复权，daec 为增强）
+- `adjust` 可选 Forward/Backward/None，默认 Forward（前复权）；None 为不复权（v2 不支持选复权，daec 为增强）
 - 执行方式：脚本将每条 `open_ts_ms`/`close_ts_ms`（毫秒）转为北京时间 ISO 字符串（YYYY-MM-DDTHH:mm:ss）
 - **已知问题**：daec 大区间响应（如多年日线，~100KB+）服务端偶发传输中断（IncompleteRead），脚本内置 5 次指数退避重试；如仍失败会非零退出。建议按需缩小日期区间

--- a/FTShare-market-data/sub-skills/index-ohlcs/scripts/handler.py
+++ b/FTShare-market-data/sub-skills/index-ohlcs/scripts/handler.py
@@ -51,7 +51,7 @@ def build_params(symbol: str, since: str, until: str, interval: str = "Day", adj
     if not _DATE_RE.match(until):
         raise ValueError(f"until 需为 YYYYMMDD（8 位数字）: {until!r}")
     params = {"symbol": symbol, "since": since, "until": until, "interval": interval}
-    if adjust is not None:
+    if adjust and adjust != "None":
         params["adjust"] = adjust
     return params
 
@@ -126,9 +126,9 @@ def main():
     )
     parser.add_argument(
         "--adjust",
-        default=None,
-        choices=["Forward", "Backward"],
-        help="复权类型：Forward（前复权）、Backward（后复权）；不传为不复权",
+        default="Forward",
+        choices=["Forward", "Backward", "None"],
+        help="复权类型：Forward（前复权，默认）、Backward（后复权）、None（不复权）",
     )
     args = parser.parse_args()
 

--- a/FTShare-market-data/sub-skills/stock-ohlcs/SKILL.md
+++ b/FTShare-market-data/sub-skills/stock-ohlcs/SKILL.md
@@ -21,7 +21,7 @@
 | since    | string | 是       | 起始日期 YYYYMMDD     | 20240101    | -                                                     |
 | until    | string | 否       | 结束日期 YYYYMMDD     | 20240131    | 不传则默认今天                                         |
 | interval | string | 否       | K 线周期              | Day         | Day（日线，默认）、Week（周线）、Month（月线）；无年线 |
-| adjust   | string | 否       | 复权类型              | Forward     | Forward（前复权）、Backward（后复权）；不传为不复权     |
+| adjust   | string | 否       | 复权类型              | Forward     | Forward（前复权，默认）、Backward（后复权）、None（不复权）     |
 
 ## 执行方式
 
@@ -72,7 +72,7 @@ python <RUN_PY> stock-ohlcs --stock 600000.XSHG --since 20230101 --interval Mont
 - `stock`、`since` 为必填；`since`/`until` 需为 YYYYMMDD（8 位数字）
 - 股票代码需携带市场后缀：沪市 .XSHG、深市 .SZ、北交所 .BJ
 - `interval` 仅支持 Day/Week/Month（daec 无年线）；不传默认 Day
-- `adjust` 可选 Forward/Backward，不传为不复权（v2 不支持选复权，daec 为增强）
+- `adjust` 可选 Forward/Backward/None，默认 Forward（前复权）；None 为不复权（v2 不支持选复权，daec 为增强）
 - 所有接口请求需携带 X-Client-Name: ft-claw 请求头
 - 执行方式：脚本将每条 `open_ts_ms`/`close_ts_ms`（毫秒）转为北京时间 ISO 字符串（YYYY-MM-DDTHH:mm:ss）
 - **已知问题**：daec 大区间响应（如多年日线，~100KB+）服务端偶发传输中断（IncompleteRead），脚本内置 5 次指数退避重试；如仍失败会非零退出。建议按需缩小日期区间

--- a/FTShare-market-data/sub-skills/stock-ohlcs/scripts/handler.py
+++ b/FTShare-market-data/sub-skills/stock-ohlcs/scripts/handler.py
@@ -51,7 +51,7 @@ def build_params(symbol: str, since: str, until: str, interval: str = "Day", adj
     if not _DATE_RE.match(until):
         raise ValueError(f"until 需为 YYYYMMDD（8 位数字）: {until!r}")
     params = {"symbol": symbol, "since": since, "until": until, "interval": interval}
-    if adjust is not None:
+    if adjust and adjust != "None":
         params["adjust"] = adjust
     return params
 
@@ -126,9 +126,9 @@ def main():
     )
     parser.add_argument(
         "--adjust",
-        default=None,
-        choices=["Forward", "Backward"],
-        help="复权类型：Forward（前复权）、Backward（后复权）；不传为不复权",
+        default="Forward",
+        choices=["Forward", "Backward", "None"],
+        help="复权类型：Forward（前复权，默认）、Backward（后复权）、None（不复权）",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
etf-ohlcs / stock-ohlcs / index-ohlcs 三个 K线 skill：
- --adjust 默认由 None（不复权）改为 Forward（前复权）
- choices 新增 None，保留取原始价（不复权）能力
- build_params 调整：adjust 为 None 时不传给 daec
- 同步更新三处 SKILL.md 参数表与注意事项

hk-candlesticks 本就默认 forward，未改动。