### PR TITLE
feat: 同步 ftshare-doc 12 篇新文档,新增 11 个子 skill

### DIFF
--- a/ftshare-market-data/README.md
+++ b/ftshare-market-data/README.md
@@ -5,7 +5,7 @@
 
 `ftshare-market-data` 是非凸科技（FT）金融行情数据的 **Skill 集**——不是 Python SDK，无需 `pip install`，**直接作为 Skill 加载到 Claude Code、Codex、OpenClaw 等 Agent 运行时即可使用**。
 
-它覆盖 A 股 / 港股 / 美股行情、财报、指数、ETF、基金、板块、资金流与宏观经济等数据：运行时读取本目录 `SKILL.md` 的 frontmatter（`name` + `description`）来决定何时触发，再通过统一的 `run.py` 路由入口执行对应子 skill（共 153 个，每个对应一条 FTShare 数据接口），子 skill 向标准输出打印 **JSON**，由运行时直接读取并交给上层投研工作流。
+它覆盖 A 股 / 港股 / 美股行情、财报、指数、ETF、基金、板块、资金流与宏观经济等数据：运行时读取本目录 `SKILL.md` 的 frontmatter（`name` + `description`）来决定何时触发，再通过统一的 `run.py` 路由入口执行对应子 skill（共 164 个，每个对应一条 FTShare 数据接口），子 skill 向标准输出打印 **JSON**，由运行时直接读取并交给上层投研工作流。
 
 ## 在 ftshare 生态中的位置
 
@@ -14,7 +14,7 @@
 ```text
 FTShare 数据服务 (market.ft.tech)
     ↓  HTTP GET（Python 标准库 urllib）
-ftshare-market-data        # run.py 统一路由 + 122 个子 skill
+ftshare-market-data        # run.py 统一路由 + 164 个子 skill
     ↓
 Claude Code / Codex / OpenClaw   # Agent 运行时加载本 Skill
     ↓
@@ -134,13 +134,13 @@ python run.py stock-ipos --all
 
 ## 能力总览
 
-122 个子 skill 按业务域组织（每个子 skill 的接口详情见其 `SKILL.md`）：
+164 个子 skill 按业务域组织（每个子 skill 的接口详情见其 `SKILL.md`）：
 
 | 域 | 代表子 skill |
 |---|---|
-| **交易日 / 财经日历 / 新闻** | `get-nth-trade-date`、`financial-calendar`、`semantic-search-news` |
-| **A 股行情 / 基础** | `stock-list-all-stocks`、`stock-quotes-list`、`stock-daec-stocks`、`stock-realtime-list`、`stock-security-info`、`stock-ipos`、`stock-ohlcs`、`stock-prices`、`stock-intraday-prices`、`block-trades`、`margin-trading-details` |
-| **A 股财报 / 业绩** | `stock-income-*`、`stock-balance-*`、`stock-cashflow-*`、`stock-performance-express-*`、`stock-performance-forecast-*` |
+| **交易日 / 财经日历 / 新闻** | `get-nth-trade-date`、`trading-calendar`、`financial-calendar`、`semantic-search-news` |
+| **A 股行情 / 基础** | `stock-list-all-stocks`、`stock-quotes-list`、`stock-daec-stocks`、`stock-realtime-list`、`stock-security-info`、`stock-ipos`、`stock-ohlcs`、`stock-prices`、`stock-intraday-prices`、`daec-ohlcs`、`eastmoney-all-board-daily-ohlc`、`block-trades`、`margin-trading-details` |
+| **A 股财报 / 业绩** | `stock-income-*`、`stock-balance-*`、`stock-cashflow-*`、`stock-performance-express-*`、`stock-performance-forecast-*`、`report-announcement-list`、`report-announcement-summary` |
 | **A 股股东 / 质押 / 增减持** | `stock-holder-ten`、`stock-holder-ften`、`stock-holder-nums`、`pledge-summary`、`pledge-detail`、`stock-share-chg` |
 | **A 股公司行动** | `shareholder-meeting`、`stock-unlock-by-stock`、`stock-unlock-by-date`、`major-contract-by-date`、`major-contract-by-symbol`、`major-contract-summary` |
 | **A 股估值 / 千股千评 / 热度 / 资金流** | `eastmoney-stock-valuation`、`eastmoney-market-valuation`、`stock-comment-index/score/org-participate/desire/focus`、`stock-rank-xueqiu`、`stock-rank-eastmoney`、`stock-capital-flows` |
@@ -153,6 +153,7 @@ python run.py stock-ipos --all
 | **板块（东财 / 同花顺）** | `eastmoney-concept-boards`、`eastmoney-board-constituents/daily-ohlc/latest-ohlc`、`10jqk-board-list/kline/all-kline` |
 | **港股** | `company-hk`、`hk-view`、`hk-valuatnanalyd`、`hk-candlesticks`、`hk-income/cashflow/balance`、`northbound`、`southbound`、`eastmoney-hk-index-daily-kline`、`hsi-daily-weight` |
 | **美股** | `eastmoney-us-stock-list/daily-ohlc/latest-ohlc`、`us-basic`、`us-income/cashflow/balance` |
+| **期货** | `futures-eod-price`、`futures-kline-intraday`、`futures-kline-latest`、`eastmoney-futures-strange`、`member-build-process`、`member-position-ranking` |
 | **宏观经济（中国 + 美国）** | `economic-china-gdp/cpi/ppi/pmi/lpr/...-monthly`（15 项）、`economic-us-economic-by-type`（16 类，按 `--type`） |
 
 ### 名称 → 代码映射

--- a/ftshare-market-data/sub-skills/daec-ohlcs/SKILL.md
+++ b/ftshare-market-data/sub-skills/daec-ohlcs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: daec-ohlcs
+description: 按标的和日期区间查询历史 OHLC K 线（DAEC）。用户提到「DAEC 历史 OHLC」「DAEC K 线」「daec ohlcs」时使用。标准模式返回 K 线数组；传入 compat=v2 返回兼容版结构，并附带前收盘价和 MA5/MA10/MA20。标准模式 since/until 必填，YYYYMMDD。
+---
+
+# 查询 DAEC 历史 OHLC
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询 DAEC 历史 OHLC |
+| 外部接口 | GET /api/v1/market/data/daec/history/ohlcs |
+| 请求方式 | GET |
+| 适用场景 | 按标的和日期区间查询历史 OHLC K 线；兼容模式可供旧前端直接消费 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 是 | 标的代码 | `600000.XSHG` | - |
+| since | string | 标准模式必填 | 起始日期 | `20260701` | YYYYMMDD |
+| until | string | 标准模式必填 | 结束日期 | `20260731` | YYYYMMDD |
+| interval | string | 否 | 周期 | `Day` | `Minute`/`Day`/`Week`/`Month`，默认 `Day` |
+| adjust | string | 否 | 复权 | `Forward` | `None`/`Forward`/`Backward` |
+| compat | string | 否 | 兼容版开关 | `v2` | 传 `v2` 启用兼容版响应 |
+| span | string | 否 | 兼容模式周期 | `DAY1` | `DAY1`/`WEEK1`/`MONTH1`，默认 `DAY1` |
+| limit | int | 否 | 兼容模式返回数量 | `250` | 默认 250 |
+| until_ts_ms | int64 | 否 | 兼容模式结束时间戳 | `1785488400000` | 毫秒；优先于默认当前日期 |
+
+## 执行方式
+
+```bash
+# 标准模式
+python <RUN_PY> daec-ohlcs --symbol 600000.XSHG --since 20260701 --until 20260731 --interval Day --adjust Forward
+# 兼容 v2 模式
+python <RUN_PY> daec-ohlcs --symbol 600000.XSHG --compat v2 --span DAY1 --limit 250
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+外层 `code/message/data`。
+
+### 标准模式
+
+`data` 直接为数组，每项字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| open_ts_ms / close_ts_ms | int64 | K 线开始 / 结束时间（毫秒） |
+| open / high / low / close | string | 开高低收 |
+| volume | int64 | 成交量 |
+| turnover | string | 成交额 |
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": [
+    {
+      "close_ts_ms": 1785488400000, "close": "10.25", "high": "10.36",
+      "low": "10.08", "open": "10.12", "open_ts_ms": 1785461400000,
+      "turnover": "126530000.00", "volume": 12345678
+    }
+  ]
+}
+```
+
+### 兼容模式（compat=v2）
+
+`data` 为对象，含 `current_time`/`has_last_empty`/`prev_close`/`ohlcs`/`ma5`/`ma10`/`ma20`。其中 `ohlcs` 使用缩写字段 `o/h/l/c/v/t/otm/ctm`。
+
+## 注意事项
+
+- 标准模式下 `since`/`until` 必填，格式 YYYYMMDD。
+- 兼容模式默认 `limit=250`，`until_ts_ms` 优先于默认当前日期。
+- 标准模式字段以字符串返回，`volume` 为 int64。

--- a/ftshare-market-data/sub-skills/daec-ohlcs/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/daec-ohlcs/scripts/handler.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""按标的和日期区间查询 DAEC 历史 OHLC K 线；传入 compat=v2 返回兼容版结构并附带前收盘价和 MA5/10/20"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/daec/history/ohlcs"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询 DAEC 历史 OHLC")
+    parser.add_argument("--symbol", required=True, help="标的代码，如 600000.XSHG")
+    parser.add_argument("--since", default=None, help="起始日期 YYYYMMDD，标准模式必填")
+    parser.add_argument("--until", default=None, help="结束日期 YYYYMMDD，标准模式必填")
+    parser.add_argument("--interval", default=None, help="周期：Minute/Day/Week/Month，默认 Day")
+    parser.add_argument("--adjust", default=None, help="复权：None/Forward/Backward")
+    parser.add_argument("--compat", default=None, help="传 v2 启用兼容版响应")
+    parser.add_argument("--span", default=None, help="兼容模式周期：DAY1/WEEK1/MONTH1，默认 DAY1")
+    parser.add_argument("--limit", type=int, default=None, help="兼容模式返回数量，默认 250")
+    parser.add_argument("--until_ts_ms", type=int, default=None,
+                        help="兼容模式结束时间戳（毫秒），优先于默认当前日期")
+    args = parser.parse_args()
+
+    if args.compat != "v2" and (args.since is None or args.until is None):
+        print("错误：标准模式下 --since 与 --until 必填", file=sys.stderr)
+        sys.exit(1)
+
+    params = {"symbol": args.symbol}
+    if args.since is not None:
+        params["since"] = args.since
+    if args.until is not None:
+        params["until"] = args.until
+    if args.interval is not None:
+        params["interval"] = args.interval
+    if args.adjust is not None:
+        params["adjust"] = args.adjust
+    if args.compat is not None:
+        params["compat"] = args.compat
+    if args.span is not None:
+        params["span"] = args.span
+    if args.limit is not None:
+        params["limit"] = args.limit
+    if args.until_ts_ms is not None:
+        params["until_ts_ms"] = args.until_ts_ms
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/eastmoney-all-board-daily-ohlc/SKILL.md
+++ b/ftshare-market-data/sub-skills/eastmoney-all-board-daily-ohlc/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: eastmoney-all-board-daily-ohlc
+description: 分页查询东方财富全部板块历史日线 OHLC（板块代码/名称/市场/日期/开高低收/成交量/成交额/振幅/涨跌幅/涨跌额/换手率）。用户提到「东财全板块日线」「全部板块 OHLC」「eastmoney all board daily ohlc」时使用。结果按板块代码、日期排序，分页返回；起止日期同时给定时跨度不得超过 3 个自然日，page_size 最大 200，支持 --all 翻页。
+---
+
+# 查询东方财富全板块日线 OHLC
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询东方财富全板块日线 OHLC |
+| 外部接口 | GET /api/v1/market/data/eastmoney-all-board-daily-ohlc |
+| 请求方式 | GET |
+| 适用场景 | 获取东方财富全部板块的历史日线 OHLC，结果按板块代码、日期排序并分页返回 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| start_date | string | 否 | 起始日期（含） | `20251127` | YYYY-MM-DD 或 YYYYMMDD |
+| end_date | string | 否 | 截止日期（含） | `2025-11-28` | YYYY-MM-DD 或 YYYYMMDD |
+| page | uint | 否 | 页码 | `1` | 从 1 开始，默认 1；传 0 时按 1 处理 |
+| page_size | uint | 否 | 每页数量 | `50` | 默认 50；传 0 时按 1 处理，最大 200 |
+
+> `start_date` 与 `end_date` 同时给出时，结束日期与开始日期相差不得超过 3 个自然日。
+
+## 执行方式
+
+```bash
+# 取一页
+python <RUN_PY> eastmoney-all-board-daily-ohlc --start_date 20251127 --end_date 2025-11-28 --page 1 --page_size 1
+# 翻全量
+python <RUN_PY> eastmoney-all-board-daily-ohlc --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+外层 `code/message/data`，分页数据位于 `data.records`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "pageNum": 1, "pageSize": 1, "total": 3, "pages": 3,
+    "records": [
+      {
+        "板块代码": "BK1024",
+        "板块名称": "绿色电力",
+        "市场": "90",
+        "日期": "2025-11-27",
+        "开盘": "1001.53",
+        "收盘": "1037.67",
+        "最高": "1041.82",
+        "最低": "1001.53",
+        "成交量": "52669555",
+        "成交额": "43012845568.00",
+        "振幅": "4.03",
+        "涨跌幅": "3.77",
+        "涨跌额": "37.67",
+        "换手率": "1.03"
+      }
+    ]
+  }
+}
+```
+
+### data 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| pageNum | int | 当前页码 |
+| pageSize | int | 每页数量 |
+| total | int | 命中总记录数 |
+| pages | int | 总页数 |
+| records | array | 当前页行情记录 |
+
+### records 元素字段（中文键）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| 板块代码 | string | 板块代码 |
+| 板块名称 | string | 板块名称 |
+| 市场 | string | 东方财富市场代码 |
+| 日期 | string | 日期，YYYY-MM-DD |
+| 开盘 / 收盘 / 最高 / 最低 | string | 开 / 收 / 高 / 低 |
+| 成交量 / 成交额 | string | 成交量 / 成交额 |
+| 振幅 / 涨跌幅 / 涨跌额 / 换手率 | string | 振幅(%) / 涨跌幅(%) / 涨跌额 / 换手率(%) |
+
+## 注意事项
+
+- 数据范围 2013-04-09 至今，不同板块的起始日期可能不同。
+- `start_date`、`end_date` 均可选；仅在二者同时传入时校验 3 个自然日的跨度。
+- `page`、`page_size` 必须是非负整数；值为 0 时按 1 处理，`page_size` 大于 200 时按 200 处理。
+- 行情记录的字段名及数值均按字符串返回；**字段名为中文**。

--- a/ftshare-market-data/sub-skills/eastmoney-all-board-daily-ohlc/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/eastmoney-all-board-daily-ohlc/scripts/handler.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""分页查询东方财富全部板块历史日线 OHLC，按板块代码、日期排序"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/eastmoney-all-board-daily-ohlc"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def fetch_page(page: int, page_size: int, **extra) -> dict:
+    params = {"page": page, "page_size": page_size}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询东方财富全板块日线 OHLC")
+    parser.add_argument("--start_date", default=None, help="起始日期（含），YYYY-MM-DD 或 YYYYMMDD")
+    parser.add_argument("--end_date", default=None, help="截止日期（含），YYYY-MM-DD 或 YYYYMMDD")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始，默认 1；传 0 时按 1 处理")
+    parser.add_argument("--page_size", type=int, default=50, help="每页数量，默认 50；传 0 时按 1 处理，最大 200")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
+    args = parser.parse_args()
+
+    extra = dict(start_date=args.start_date, end_date=args.end_date)
+
+    if args.fetch_all:
+        first = fetch_page(1, args.page_size, **extra)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            d = fetch_page(p, args.page_size, **extra).get("data") or {}
+            records.extend(d.get("records", []))
+        result = {
+            "code": first.get("code"), "message": first.get("message"),
+            "data": {"pageNum": 1, "pageSize": args.page_size,
+                     "total": data.get("total", len(records)), "pages": pages, "records": records},
+        }
+    else:
+        result = fetch_page(args.page, args.page_size, **extra)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/eastmoney-futures-strange/SKILL.md
+++ b/ftshare-market-data/sub-skills/eastmoney-futures-strange/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: eastmoney-futures-strange
+description: 查询东方财富期货龙虎榜面板（成交量/持仓量多空排名等）。用户提到「东财期货龙虎榜」「期货龙虎榜面板」「期货会员排名」「eastmoney futures strange」时使用。按交易所/品种/合约/交易日返回完整面板数组，不分页。
+---
+
+# 查询东方财富期货龙虎榜
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询东方财富期货龙虎榜 |
+| 外部接口 | GET /api/v1/market/data/eastmoney-futures-strange |
+| 请求方式 | GET |
+| 适用场景 | 查询指定交易所、品种、合约和交易日的东方财富期货龙虎榜面板，包括占比切片、会员排名和汇总数据 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| exchange | string | 是 | 交易所代码 | `dce` | `shfe`/`dce`/`czce`/`cffex`/`ine`/`gfe` |
+| variety | string | 是 | 品种名称 | `多晶硅` | 中文名称，URL 编码后传入 |
+| contract | string | 是 | 合约代码 | `ps2609` | 小写合约代码 |
+| trade_date | string | 是 | 交易日 | `20260721` | `YYYYMMDD` |
+
+## 执行方式
+
+```bash
+python <RUN_PY> eastmoney-futures-strange --exchange dce --variety 多晶硅 --contract ps2609 --trade_date 20260721
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回统一结构 `code/message/data`，`data` 为面板数组（不分页）。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": [
+    {
+      "key": "volume_rank",
+      "title": "成交量龙虎榜",
+      "slices": null,
+      "rows": [{"rank": 1, "member_name": "东证期货（代客）", "value": 24952, "change": -4961}],
+      "summary": {"today_total": 175902, "previous_total": 218790, "total_change": -42888}
+    }
+  ]
+}
+```
+
+### data 元素字段
+
+| 字段 | 类型 | 是否可为空 | 说明 |
+|------|------|------------|------|
+| key | string | 否 | 面板标识 |
+| title | string | 否 | 面板标题 |
+| slices | array/null | 是 | 饼图切片；每项含 `name`/`value`/`percent` |
+| rows | array/null | 是 | 排名记录；每项含 `rank`/`member_id`/`member_name`/`value`/`change` |
+| summary | object/null | 是 | 汇总；含 `today_total`/`previous_total`/`total_change` |
+
+## 注意事项
+
+- 所有参数均为必填，缺一返回 400。
+- 单次返回该合约对应的完整面板数组，不分页。
+- `variety` 为中文品种名称，调用时通过 URL 编码传入。
+- HTTP 恒为 200，业务错误通过 `code`/`message` 携带。

--- a/ftshare-market-data/sub-skills/eastmoney-futures-strange/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/eastmoney-futures-strange/scripts/handler.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""查询东方财富期货龙虎榜面板（成交量/持仓量多空排名等），按交易所/品种/合约/交易日"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/eastmoney-futures-strange"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询东方财富期货龙虎榜面板")
+    parser.add_argument("--exchange", required=True, help="交易所代码：shfe/dce/czce/cffex/ine/gfe")
+    parser.add_argument("--variety", required=True, help="品种名称，如 多晶硅")
+    parser.add_argument("--contract", required=True, help="合约代码，如 ps2609")
+    parser.add_argument("--trade_date", required=True, help="交易日 YYYYMMDD")
+    args = parser.parse_args()
+
+    params = {
+        "exchange": args.exchange,
+        "variety": args.variety,
+        "contract": args.contract,
+        "trade_date": args.trade_date,
+    }
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/futures-eod-price/SKILL.md
+++ b/ftshare-market-data/sub-skills/futures-eod-price/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: futures-eod-price
+description: 分页查询期货日终行情（开高低收/结算价/前结算价/涨跌额/成交量/成交额/持仓量）。用户提到「期货日终行情」「期货 EOD」「期货日线行情」「futures eod price」时使用。按交易所/合约/精确交易日或日期区间过滤，分页返回，page_size 最大 200，支持 --all 翻页。
+---
+
+# 查询期货日终行情
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询期货日终行情 |
+| 外部接口 | GET /api/v1/market/data/futures/eod-price |
+| 请求方式 | GET |
+| 适用场景 | 分页查询期货日终行情，包括开高低收、结算价、成交量、成交额和持仓量等字段 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| exchange | string | 否 | 交易所代码 | `SHFE` | 精确匹配 |
+| symbol | string | 否 | 合约代码 | `rb2610` | 精确匹配 |
+| trade_date | int | 否 | 精确交易日 | `20260721` | 8 位 YYYYMMDD；**与 start_date/end_date 互斥** |
+| start_date | int | 否 | 起始交易日 | `20260701` | 8 位 YYYYMMDD；须与 end_date 同时提供 |
+| end_date | int | 否 | 结束交易日 | `20260721` | 8 位 YYYYMMDD；须与 start_date 同时提供 |
+| page | int | 否 | 页码 | `1` | 默认 1 |
+| page_size | int | 否 | 每页条数 | `50` | 默认 50，最大 200 |
+
+> `trade_date` 不可与 `start_date`/`end_date` 同时使用；同时提供起止日期时需满足 `start_date <= end_date`。
+
+## 执行方式
+
+```bash
+# 查某合约某日日终行情
+python <RUN_PY> futures-eod-price --exchange SHFE --symbol rb2610 --trade_date 20260721 --page 1 --page_size 20
+# 查某合约日期区间
+python <RUN_PY> futures-eod-price --symbol rb2610 --start_date 20260701 --end_date 20260721
+# 自动翻页获取全量
+python <RUN_PY> futures-eod-price --exchange SHFE --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回 `code/message/data`，分页数据位于 `data.records`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "pageNum": 1, "pageSize": 20, "total": 1, "pages": 1,
+    "records": [
+      {
+        "trade_date": 20260721, "exchange": "SHFE", "symbol": "rb2610",
+        "open_price": "3210", "highest_price": "3212", "lowest_price": "3208", "close_price": "3211",
+        "settlement_price": "3205", "pre_settlement_price": "3198",
+        "up_down_1": "13", "up_down_2": "7",
+        "volume": 1234, "amount": "39621740.00",
+        "open_interest": "456789", "open_interest_change": "-1000",
+        "updated_at": "2026-07-21 15:00:00"
+      }
+    ]
+  }
+}
+```
+
+### records 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| trade_date | int | 交易日 |
+| exchange | string | 交易所 |
+| symbol | string | 合约代码 |
+| open_price / highest_price / lowest_price / close_price | string | 开 / 最高 / 最低 / 收 |
+| settlement_price / pre_settlement_price | string | 结算价 / 前结算价 |
+| up_down_1 / up_down_2 | string | 涨跌额口径一 / 口径二 |
+| volume | int64 | 成交量 |
+| amount | string | 成交额 |
+| open_interest / open_interest_change | string | 持仓量 / 持仓量变化 |
+| updated_at | string | 更新时间 |
+
+## 注意事项
+
+- `trade_date` 与 `start_date`/`end_date` 互斥；`start_date`/`end_date` 必须成对且 `start_date <= end_date`。
+- `page_size` 最大 200，超过按 200 处理。
+- 多数价格/金额字段以字符串返回，`volume` 为 int64。
+- HTTP 恒为 200，业务错误通过 `code`/`message` 携带。

--- a/ftshare-market-data/sub-skills/futures-eod-price/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/futures-eod-price/scripts/handler.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""分页查询期货日终行情（开高低收/结算价/成交量/成交额/持仓量），按交易所/合约/交易日或区间"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/futures/eod-price"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def fetch_page(page: int, page_size: int, **extra) -> dict:
+    params = {"page": page, "page_size": page_size}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询期货日终行情")
+    parser.add_argument("--exchange", default=None, help="交易所代码，如 SHFE/DCE/CZCE/CFFEX/INE/GFE")
+    parser.add_argument("--symbol", default=None, help="合约代码，精确匹配")
+    parser.add_argument("--trade_date", type=int, default=None, help="精确交易日 YYYYMMDD；与 start_date/end_date 互斥")
+    parser.add_argument("--start_date", type=int, default=None, help="起始交易日 YYYYMMDD；须与 end_date 同时提供")
+    parser.add_argument("--end_date", type=int, default=None, help="结束交易日 YYYYMMDD；须与 start_date 同时提供")
+    parser.add_argument("--page", type=int, default=1, help="页码（默认 1）")
+    parser.add_argument("--page_size", type=int, default=50, help="每页条数（默认 50，最大 200）")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量")
+    args = parser.parse_args()
+
+    if args.trade_date is not None and (args.start_date is not None or args.end_date is not None):
+        print("错误：--trade_date 不可与 --start_date/--end_date 同时使用", file=sys.stderr)
+        sys.exit(1)
+    if (args.start_date is None) != (args.end_date is None):
+        print("错误：--start_date 与 --end_date 必须同时提供", file=sys.stderr)
+        sys.exit(1)
+
+    extra = dict(exchange=args.exchange, symbol=args.symbol, trade_date=args.trade_date,
+                 start_date=args.start_date, end_date=args.end_date)
+
+    if args.fetch_all:
+        first = fetch_page(1, args.page_size, **extra)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            d = fetch_page(p, args.page_size, **extra).get("data") or {}
+            records.extend(d.get("records", []))
+        result = {
+            "code": first.get("code"), "message": first.get("message"),
+            "data": {"pageNum": 1, "pageSize": args.page_size,
+                     "total": data.get("total", len(records)), "pages": pages, "records": records},
+        }
+    else:
+        result = fetch_page(args.page, args.page_size, **extra)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/futures-kline-intraday/SKILL.md
+++ b/ftshare-market-data/sub-skills/futures-kline-intraday/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: futures-kline-intraday
+description: 查询期货合约日内 1 分钟 K 线序列（开高低收/成交量/成交额/VWAP/持仓量/结算价/涨跌停价）。用户提到「期货日内K线」「期货分钟K线」「期货 1min K 线」「futures kline intraday」时使用。按毫秒时间戳区间过滤，默认 600 条，最大 1000 条；起止时间跨度不得超过 3 天。
+---
+
+# 查询期货日内 K 线
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询期货日内 K 线 |
+| 外部接口 | GET /api/v1/market/data/futures/kline/intraday |
+| 请求方式 | GET |
+| 适用场景 | 从实时行情表查询指定期货合约的 1 分钟 K 线序列，可按毫秒时间戳区间过滤 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 是 | WIND 合约全码或表内合约代码 | `rb2610` / `A2605.DCE` | - |
+| interval | string | 否 | K 线周期 | `1min` | 当前仅支持 `1min`，兼容 `1m`，默认 `1min` |
+| start | int64 | 否 | 开始时间 | `1784601060000` | 毫秒时间戳，闭区间 |
+| end | int64 | 否 | 结束时间 | `1784687460000` | 毫秒时间戳，闭区间 |
+| limit | int | 否 | 最大返回条数 | `600` | 默认 600，范围 1~1000 |
+
+> 同时提供 `start` 和 `end` 时，时间跨度不得超过 3 天。
+
+## 执行方式
+
+```bash
+# 取最新 600 根 1 分钟 K 线
+python <RUN_PY> futures-kline-intraday --symbol rb2610 --interval 1min --limit 600
+# 按时间区间过滤
+python <RUN_PY> futures-kline-intraday --symbol rb2610 --start 1784601060000 --end 1784687460000
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+外层 `code/message/data`，`data` 为 `{ "items": [...] }`。`items` 元素字段与「期货最新K线」的 `item` 相同。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "items": [
+      {
+        "bar_interval": "1min", "symbol": "rb2610", "variety": "rb", "exchange": "SHFE",
+        "datetime": 1784601060000, "trade_date": 20260721,
+        "open": 3210.0, "high": 3212.0, "low": 3208.0, "close": 3211.0,
+        "volume": 1234, "amount": 39621740.0, "vwap": 3210.84,
+        "open_interest": 456789.0,
+        "pre_settlement_price": 3198.0, "settlement_price": 3205.0,
+        "high_limit_price": 3450.0, "low_limit_price": 2940.0, "pre_close_price": 3200.0,
+        "updated_at": 1784601061000
+      }
+    ]
+  }
+}
+```
+
+### items 元素字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| bar_interval | string | K 线周期 |
+| symbol / variety / exchange | string | 合约代码 / 品种 / 交易所 |
+| datetime | int64 | K 线时间，毫秒时间戳 |
+| trade_date | int | 交易日 YYYYMMDD |
+| open / high / low / close | float | 开高低收 |
+| volume | int64 | 成交量 |
+| amount | float | 成交额 |
+| vwap | float | 成交量加权均价 |
+| open_interest | float | 持仓量 |
+| pre_settlement_price / settlement_price | float | 前结算价 / 结算价 |
+| high_limit_price / low_limit_price | float | 涨停价 / 跌停价 |
+| pre_close_price | float | 前收盘价 |
+| updated_at | int64 | 实时表写入时间，毫秒时间戳 |
+
+## 注意事项
+
+- `interval` 当前仅支持 `1min`（兼容 `1m`）。
+- 默认返回 600 条，最多 1000 条。
+- `start`/`end` 同时提供时跨度不得超过 3 天，否则 400。
+- 数据来自实时行情表，仅保留近期 1 分钟 K 线。

--- a/ftshare-market-data/sub-skills/futures-kline-intraday/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/futures-kline-intraday/scripts/handler.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""查询期货合约日内 1 分钟 K 线序列，可按毫秒时间戳区间过滤，最大 1000 条"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/futures/kline/intraday"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询期货日内 1 分钟 K 线")
+    parser.add_argument("--symbol", required=True, help="WIND 合约全码或表内合约代码，如 rb2610 / A2605.DCE")
+    parser.add_argument("--interval", default="1min", help="K 线周期，当前仅支持 1min（兼容 1m），默认 1min")
+    parser.add_argument("--start", type=int, default=None, help="开始时间，毫秒时间戳，闭区间")
+    parser.add_argument("--end", type=int, default=None, help="结束时间，毫秒时间戳，闭区间")
+    parser.add_argument("--limit", type=int, default=600, help="最大返回条数，默认 600，范围 1~1000")
+    args = parser.parse_args()
+
+    if args.start is not None and args.end is not None and args.end < args.start:
+        print("错误：--end 不得早于 --start", file=sys.stderr)
+        sys.exit(1)
+
+    params = {"symbol": args.symbol, "interval": args.interval, "limit": args.limit}
+    if args.start is not None:
+        params["start"] = args.start
+    if args.end is not None:
+        params["end"] = args.end
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/futures-kline-latest/SKILL.md
+++ b/ftshare-market-data/sub-skills/futures-kline-latest/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: futures-kline-latest
+description: 查询期货合约最新一根 1 分钟 K 线（开高低收/成交量/成交额/VWAP/持仓量/结算价/涨跌停价）。用户提到「期货最新K线」「期货实时K线」「期货最新 1min」「futures kline latest」时使用。未找到数据时 data.item 为 null。
+---
+
+# 查询期货最新 K 线
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询期货最新 K 线 |
+| 外部接口 | GET /api/v1/market/data/futures/kline/latest |
+| 请求方式 | GET |
+| 适用场景 | 从实时行情表读取指定期货合约最新一根 1 分钟 K 线 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 是 | WIND 合约全码或表内合约代码 | `A2605.DCE` / `a2605` | - |
+| interval | string | 否 | K 线周期 | `1min` | 当前仅支持 `1min`，兼容 `1m`，默认 `1min` |
+
+## 执行方式
+
+```bash
+python <RUN_PY> futures-kline-latest --symbol A2605.DCE --interval 1min
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+外层 `code/message/data`，`data` 为 `{ "item": object|null }`。未找到数据时 `item` 为 `null`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "item": {
+      "bar_interval": "1min", "symbol": "A2605.DCE", "variety": "a", "exchange": "DCE",
+      "datetime": 1784601060000, "trade_date": 20260721,
+      "open": 3210.0, "high": 3212.0, "low": 3208.0, "close": 3211.0,
+      "volume": 1234, "amount": 39621740.0, "vwap": 3210.84,
+      "open_interest": 456789.0,
+      "pre_settlement_price": 3198.0, "settlement_price": 3205.0,
+      "high_limit_price": 3450.0, "low_limit_price": 2940.0, "pre_close_price": 3200.0,
+      "updated_at": 1784601061000
+    }
+  }
+}
+```
+
+### item 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| bar_interval | string | K 线周期 |
+| symbol / variety / exchange | string | 合约代码 / 品种 / 交易所 |
+| datetime | int64 | K 线时间，毫秒时间戳 |
+| trade_date | int | 交易日 YYYYMMDD |
+| open / high / low / close | float | 开高低收 |
+| volume | int64 | 成交量 |
+| amount | float | 成交额 |
+| vwap | float | 成交量加权均价 |
+| open_interest | float | 持仓量 |
+| pre_settlement_price / settlement_price | float | 前结算价 / 结算价 |
+| high_limit_price / low_limit_price | float | 涨停价 / 跌停价 |
+| pre_close_price | float | 前收盘价 |
+| updated_at | int64 | 实时表写入时间，毫秒时间戳 |
+
+## 注意事项
+
+- `interval` 当前仅支持 `1min`（兼容 `1m`）。
+- 单次返回单条；未找到数据时 `data.item` 为 `null`。
+- 数据来自实时行情表。

--- a/ftshare-market-data/sub-skills/futures-kline-latest/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/futures-kline-latest/scripts/handler.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""查询期货合约最新一根 1 分钟 K 线，未找到数据时 data.item 为 null"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/futures/kline/latest"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询期货最新 1 分钟 K 线")
+    parser.add_argument("--symbol", required=True, help="WIND 合约全码（如 A2605.DCE）或表内合约代码（如 a2605）")
+    parser.add_argument("--interval", default="1min", help="K 线周期，当前仅支持 1min（兼容 1m），默认 1min")
+    args = parser.parse_args()
+
+    qs = urllib.parse.urlencode({"symbol": args.symbol, "interval": args.interval})
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/member-build-process/SKILL.md
+++ b/ftshare-market-data/sub-skills/member-build-process/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: member-build-process
+description: 查询单个期货会员在指定合约/日期区间的持仓变化，并结合合约行情估算每日及累计盈亏。用户提到「会员建仓过程」「期货会员持仓盈亏」「会员净持仓变化」「member build process」时使用。按交易所/会员/合约过滤，可选日期区间和合约乘数，分页返回，page_size 最大 200，支持 --all 翻页。
+---
+
+# 查询期货会员建仓过程
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询期货会员建仓过程 |
+| 外部接口 | GET /api/v1/market/data/member-build-process |
+| 请求方式 | GET |
+| 适用场景 | 查询单个期货会员在指定合约和日期区间内的持仓变化，并结合合约行情估算每日及累计盈亏 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| exchange | string | 是 | 交易所代码 | `DCE` | `SHFE`/`DCE`/`CZCE` 等 |
+| member_name | string | 是 | 会员名称 | `永安期货` | 中文，URL 编码后传入 |
+| instrument_id | string | 是 | 合约代码 | `a2609` | - |
+| start_date | string | 否 | 起始日期 | `20260701` | YYYYMMDD 或 YYYY-MM-DD，默认 `20260101` |
+| end_date | string | 否 | 结束日期 | `20260721` | YYYYMMDD 或 YYYY-MM-DD，默认当天 |
+| contract_multiplier | float | 否 | 合约乘数 | `10` | 不传时按品种默认表推导 |
+| page | int | 否 | 页码 | `1` | 默认 1 |
+| page_size | int | 否 | 每页条数 | `50` | 默认 50，最大 200 |
+
+## 执行方式
+
+```bash
+# 查某会员某合约某区间建仓过程
+python <RUN_PY> member-build-process --exchange DCE --member_name 永安期货 --instrument_id a2609 --start_date 20260701 --end_date 20260721
+# 指定合约乘数
+python <RUN_PY> member-build-process --exchange SHFE --member_name 永安期货 --instrument_id rb2601 --contract_multiplier 10 --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回 `code/message/data`，记录位于 `data.records`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "pageNum": 1, "pageSize": 50, "total": 15, "pages": 1,
+    "records": [
+      {
+        "trade_date": "2026-07-21", "exchange": "DCE", "instrument_id": "a2609",
+        "product_name": "豆一", "member_name": "永安期货",
+        "volume_rank": 1, "value": 10000, "change": 100,
+        "long_rank": 2, "long_value": 5000, "long_change": 200,
+        "short_rank": null, "short_value": null, "short_change": null,
+        "net_position": 5000, "observed_side": "long",
+        "open_price": "4200", "high_price": "4220", "low_price": "4180", "close_price": "4210",
+        "settlement_price": "4205", "pre_settlement_price": "4198",
+        "volume": "12345", "open_interest": "45678", "open_interest_change": "-100",
+        "contract_multiplier": 10,
+        "estimated_net_change": 100,
+        "estimated_position_cost": 42000000.0,
+        "estimated_daily_pnl": 5000.0, "estimated_daily_pnl_wan": 0.5,
+        "estimated_cumulative_pnl": 25000.0, "estimated_cumulative_pnl_wan": 2.5
+      }
+    ]
+  }
+}
+```
+
+### records 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| trade_date | string | 交易日 |
+| exchange / instrument_id / product_name / member_name | string | 交易所 / 合约代码 / 品种名称 / 会员名称 |
+| volume_rank / value / change | int/null | 成交排名 / 成交量 / 变化 |
+| long_rank / long_value / long_change | int/null | 多头排名 / 持仓量 / 变化 |
+| short_rank / short_value / short_change | int/null | 空头排名 / 持仓量 / 变化 |
+| net_position | int/null | 净持仓 |
+| observed_side | string | 观察方向 |
+| open_price / high_price / low_price / close_price | string/null | 当日开高低收 |
+| settlement_price / pre_settlement_price | string/null | 结算价 / 前结算价 |
+| volume / open_interest / open_interest_change | string/null | 合约成交量 / 持仓量 / 持仓量变化 |
+| contract_multiplier | float/null | 合约乘数 |
+| estimated_net_change | int/null | 估算净持仓变化 |
+| estimated_position_cost | float/null | 估算持仓成本 |
+| estimated_daily_pnl / estimated_daily_pnl_wan | float/null | 估算当日盈亏 / 万元 |
+| estimated_cumulative_pnl / estimated_cumulative_pnl_wan | float/null | 估算累计盈亏 / 万元 |
+
+## 注意事项
+
+- `exchange`/`member_name`/`instrument_id` 三者为必填。
+- `contract_multiplier` 不传时按品种默认表推导；不同品种乘数不同，影响盈亏估算结果。
+- 多数价格/数量字段以字符串返回，估算字段为 float。
+- `page_size` 最大 200。

--- a/ftshare-market-data/sub-skills/member-build-process/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/member-build-process/scripts/handler.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""分页查询单个期货会员在指定合约/日期区间的持仓变化，并结合合约行情估算每日及累计盈亏"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/member-build-process"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def fetch_page(page: int, page_size: int, **extra) -> dict:
+    params = {"page": page, "page_size": page_size}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询期货会员建仓过程")
+    parser.add_argument("--exchange", required=True, help="交易所代码，如 SHFE/DCE/CZCE")
+    parser.add_argument("--member_name", required=True, help="会员名称，如 永安期货")
+    parser.add_argument("--instrument_id", required=True, help="合约代码，如 rb2601")
+    parser.add_argument("--start_date", default=None, help="起始日期 YYYYMMDD 或 YYYY-MM-DD，默认 20260101")
+    parser.add_argument("--end_date", default=None, help="结束日期 YYYYMMDD 或 YYYY-MM-DD，默认当天")
+    parser.add_argument("--contract_multiplier", type=float, default=None,
+                        help="合约乘数；不传时按品种默认表推导")
+    parser.add_argument("--page", type=int, default=1, help="页码（默认 1）")
+    parser.add_argument("--page_size", type=int, default=50, help="每页条数（默认 50，最大 200）")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量")
+    args = parser.parse_args()
+
+    extra = dict(exchange=args.exchange, member_name=args.member_name, instrument_id=args.instrument_id,
+                 start_date=args.start_date, end_date=args.end_date,
+                 contract_multiplier=args.contract_multiplier)
+
+    if args.fetch_all:
+        first = fetch_page(1, args.page_size, **extra)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            d = fetch_page(p, args.page_size, **extra).get("data") or {}
+            records.extend(d.get("records", []))
+        result = {
+            "code": first.get("code"), "message": first.get("message"),
+            "data": {"pageNum": 1, "pageSize": args.page_size,
+                     "total": data.get("total", len(records)), "pages": pages, "records": records},
+        }
+    else:
+        result = fetch_page(args.page, args.page_size, **extra)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/member-position-ranking/SKILL.md
+++ b/ftshare-market-data/sub-skills/member-position-ranking/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: member-position-ranking
+description: 查询指定交易日/交易所/合约/方向的期货会员持仓排名（品种/合约/方向/会员/持仓量/持仓量变化/净持仓）。用户提到「会员持仓排名」「期货会员持仓」「多头排名」「空头排名」「member position ranking」时使用。按交易所/合约/交易日/方向过滤，分页返回，page_size 最大 200，支持 --all 翻页。
+---
+
+# 查询期货会员持仓排名
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询期货会员持仓排名 |
+| 外部接口 | GET /api/v1/market/data/member-position-ranking |
+| 请求方式 | GET |
+| 适用场景 | 查询指定交易日、交易所、合约及方向的期货会员持仓排名 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| exchange | string | 是 | 交易所代码 | `DCE` | `SHFE`/`DCE`/`CZCE` 等 |
+| instrument_id | string | 是 | 合约代码 | `a2605` | - |
+| trade_date | string | 是 | 交易日 | `20260721` | YYYYMMDD 或 YYYY-MM-DD |
+| direction | string | 是 | 查询方向 | `long` | `long` 或 `short`，也接受常见中文和缩写别名 |
+| page | int | 否 | 页码 | `1` | 默认 1 |
+| page_size | int | 否 | 每页条数 | `50` | 默认 50，最大 200 |
+
+## 执行方式
+
+```bash
+# 查某合约某日多头会员排名
+python <RUN_PY> member-position-ranking --exchange DCE --instrument_id a2605 --trade_date 20260721 --direction long
+# 查空头排名并翻全量
+python <RUN_PY> member-position-ranking --exchange SHFE --instrument_id rb2610 --trade_date 20260721 --direction short --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回 `code/message/data`，记录位于 `data.records`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "pageNum": 1, "pageSize": 50, "total": 100, "pages": 2,
+    "records": [
+      {
+        "variety": "a", "code": "a2605", "date": "2026-07-21",
+        "direction": "long", "broker": "永安期货",
+        "oi": 10000, "oi_chg": 200, "net_position": 5000
+      }
+    ]
+  }
+}
+```
+
+### records 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| variety | string | 品种名称或代码 |
+| code | string | 合约代码 |
+| date | string | 交易日 |
+| direction | string | 持仓方向 |
+| broker | string | 期货会员名称 |
+| oi | int64/null | 持仓量 |
+| oi_chg | int64/null | 持仓量变化 |
+| net_position | int64/null | 净持仓 |
+
+## 注意事项
+
+- `exchange`/`instrument_id`/`trade_date`/`direction` 四者均为必填。
+- `direction` 接受 `long`/`short` 及常见中文和缩写别名。
+- `page_size` 最大 200。

--- a/ftshare-market-data/sub-skills/member-position-ranking/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/member-position-ranking/scripts/handler.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""分页查询指定交易日/交易所/合约/方向的期货会员持仓排名"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/member-position-ranking"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def fetch_page(page: int, page_size: int, **extra) -> dict:
+    params = {"page": page, "page_size": page_size}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询期货会员持仓排名")
+    parser.add_argument("--exchange", required=True, help="交易所代码，如 SHFE/DCE/CZCE")
+    parser.add_argument("--instrument_id", required=True, help="合约代码，如 a2605")
+    parser.add_argument("--trade_date", required=True, help="交易日 YYYYMMDD 或 YYYY-MM-DD")
+    parser.add_argument("--direction", required=True, help="查询方向：long 或 short（也接受常见中文和缩写别名）")
+    parser.add_argument("--page", type=int, default=1, help="页码（默认 1）")
+    parser.add_argument("--page_size", type=int, default=50, help="每页条数（默认 50，最大 200）")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量")
+    args = parser.parse_args()
+
+    extra = dict(exchange=args.exchange, instrument_id=args.instrument_id,
+                 trade_date=args.trade_date, direction=args.direction)
+
+    if args.fetch_all:
+        first = fetch_page(1, args.page_size, **extra)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            d = fetch_page(p, args.page_size, **extra).get("data") or {}
+            records.extend(d.get("records", []))
+        result = {
+            "code": first.get("code"), "message": first.get("message"),
+            "data": {"pageNum": 1, "pageSize": args.page_size,
+                     "total": data.get("total", len(records)), "pages": pages, "records": records},
+        }
+    else:
+        result = fetch_page(args.page, args.page_size, **extra)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/report-announcement-list/SKILL.md
+++ b/ftshare-market-data/sub-skills/report-announcement-list/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: report-announcement-list
+description: 按公告日期分页查询报告公告列表，可选按证券代码过滤。用户提到「报告公告列表」「公告列表」「某日公告」「report announcement list」时使用。返回公告标题/附件信息/处理状态和公告 ID；公告 ID 可用于查询公告摘要。分页返回，page_size 最大 200，支持 --all 翻页。
+---
+
+# 查询报告公告列表
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询报告公告列表 |
+| 外部接口 | GET /api/v1/market/data/report-announcements/list |
+| 请求方式 | GET |
+| 适用场景 | 按公告日期分页查询报告公告，可选按证券代码过滤；公告 ID 可用于查询公告摘要 |
+
+> 同一处理逻辑的兼容入口还包括 `/api/v1/market/data/report-announcement/list`。
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| date | string | 是 | 公告日期 | `20260714` | YYYYMMDD 或 YYYY-MM-DD |
+| sec_code | string | 否 | 证券代码 | `600000` | 不传返回当天全部证券公告 |
+| page | int | 否 | 页码 | `1` | 从 1 开始，默认 1 |
+| page_size | int | 否 | 每页数量 | `50` | 默认 50，最大 200 |
+
+## 执行方式
+
+```bash
+# 某日某证券公告
+python <RUN_PY> report-announcement-list --date 20260714 --sec_code 600000 --page 1 --page_size 20
+# 某日全部公告并翻全量
+python <RUN_PY> report-announcement-list --date 20260714 --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回 `code/message/data`，分页数据位于 `data.records`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "pageNum": 1, "pageSize": 20, "total": 50, "pages": 3,
+    "records": [
+      {
+        "id": 12345,
+        "announcement_id": "AN202607140001",
+        "url_hash": "...",
+        "sec_code": "600000",
+        "sec_name": "浦发银行",
+        "announcement_title": "...",
+        "announcement_time": "2026-07-14 09:30:00",
+        "adjunct_type": "PDF", "adjunct_size": 102400,
+        "column_type": "monthly", "plate": "sh",
+        "status": "summarized", "retry_count": 0,
+        "created_at": "2026-07-14 09:30:00",
+        "updated_at": "2026-07-14 10:00:00",
+        "processed_at": "2026-07-14 10:01:00"
+      }
+    ]
+  }
+}
+```
+
+### data 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| pageNum | int | 当前页码 |
+| pageSize | int | 当前每页条数 |
+| total | int | 满足条件的总记录数 |
+| pages | int | 总页数；无记录时为 0 |
+| records | array | 当前页公告记录 |
+
+### records 元素字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | int64/null | 数据库记录 ID |
+| announcement_id | string/null | 公告 ID |
+| url_hash | string/null | 公告附件哈希 |
+| sec_code / sec_name | string/null | 证券代码 / 证券名称 |
+| announcement_title | string/null | 公告标题 |
+| announcement_time | string/null | 公告时间 |
+| adjunct_type | string/null | 附件类型 |
+| adjunct_size | int64/null | 附件大小 |
+| column_type | string/null | 公告栏目类型 |
+| plate | string/null | 所属板块 |
+| status | string/null | 处理状态 |
+| retry_count | int64/null | 重试次数 |
+| created_at / updated_at / processed_at | string/null | 创建 / 更新 / 处理时间 |
+
+## 注意事项
+
+- `date` 为必填，支持 YYYYMMDD 或 YYYY-MM-DD。
+- `page_size` 最大 200。
+- 取得 `announcement_id` 后可调用 `report-announcement-summary` 查询公告摘要。
+- 两个路径（`/report-announcements/list` 与 `/report-announcement/list`）是同一处理逻辑的兼容入口。

--- a/ftshare-market-data/sub-skills/report-announcement-list/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/report-announcement-list/scripts/handler.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""分页查询报告公告列表，可选按证券代码过滤；公告 ID 可用于查询公告摘要"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/report-announcements/list"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def fetch_page(page: int, page_size: int, **extra) -> dict:
+    params = {"page": page, "page_size": page_size}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    qs = urllib.parse.urlencode(params)
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询报告公告列表")
+    parser.add_argument("--date", required=True, help="公告日期 YYYYMMDD 或 YYYY-MM-DD")
+    parser.add_argument("--sec_code", default=None, help="证券代码；不传返回当天全部证券公告")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始，默认 1")
+    parser.add_argument("--page_size", type=int, default=50, help="每页数量，默认 50，最大 200")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量")
+    args = parser.parse_args()
+
+    extra = dict(date=args.date, sec_code=args.sec_code)
+
+    if args.fetch_all:
+        first = fetch_page(1, args.page_size, **extra)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            d = fetch_page(p, args.page_size, **extra).get("data") or {}
+            records.extend(d.get("records", []))
+        result = {
+            "code": first.get("code"), "message": first.get("message"),
+            "data": {"pageNum": 1, "pageSize": args.page_size,
+                     "total": data.get("total", len(records)), "pages": pages, "records": records},
+        }
+    else:
+        result = fetch_page(args.page, args.page_size, **extra)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/report-announcement-summary/SKILL.md
+++ b/ftshare-market-data/sub-skills/report-announcement-summary/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: report-announcement-summary
+description: 根据公告 ID 查询单条报告公告的摘要、标题、证券信息和处理状态。用户提到「报告公告摘要」「公告摘要」「单条公告详情」「report announcement summary」时使用。未找到公告时 data 为 null、code 为 404。
+---
+
+# 查询报告公告摘要
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询报告公告摘要 |
+| 外部接口 | GET /api/v1/market/data/report-announcements/summary |
+| 请求方式 | GET |
+| 适用场景 | 根据公告 ID 查询单条报告公告的摘要、标题、证券信息和处理状态 |
+
+> 同一处理逻辑的兼容入口还包括 `/api/v1/market/data/report-announcement/summary`。
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| announcement_id | string | 是 | 公告 ID | `AN202607140001` | 由「报告公告列表」接口返回 |
+
+## 执行方式
+
+```bash
+python <RUN_PY> report-announcement-summary --announcement_id AN202607140001
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回 `code/message/data`，未找到公告时 `code` 为 404、`data` 为 `null`。
+
+```json
+{
+  "code": 200,
+  "message": "success",
+  "data": {
+    "announcement_id": "AN202607140001",
+    "sec_code": "600000",
+    "sec_name": "浦发银行",
+    "announcement_title": "公告标题",
+    "summary": "公告摘要",
+    "status": "summarized",
+    "announcement_time": "2026-07-14 09:30:00"
+  }
+}
+```
+
+### data 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| announcement_id | string/null | 公告 ID |
+| sec_code / sec_name | string/null | 证券代码 / 证券名称 |
+| announcement_title | string/null | 公告标题 |
+| summary | string/null | 公告摘要 |
+| status | string/null | 摘要处理状态 |
+| announcement_time | string/null | 公告时间 |
+
+## 注意事项
+
+- `announcement_id` 为必填，由「报告公告列表」接口返回。
+- 未找到公告时 `code` 为 404、`data` 为 `null`。
+- 两个路径（`/report-announcements/summary` 与 `/report-announcement/summary`）是同一处理逻辑的兼容入口。

--- a/ftshare-market-data/sub-skills/report-announcement-summary/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/report-announcement-summary/scripts/handler.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""根据公告 ID 查询单条报告公告的摘要、标题、证券信息和处理状态"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/report-announcements/summary"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询报告公告摘要")
+    parser.add_argument("--announcement_id", required=True, help="公告 ID，由「报告公告列表」接口返回")
+    args = parser.parse_args()
+
+    qs = urllib.parse.urlencode({"announcement_id": args.announcement_id})
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/trading-calendar/SKILL.md
+++ b/ftshare-market-data/sub-skills/trading-calendar/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: trading-calendar
+description: 查询中国内地（cn）或香港（hk）市场在指定闭区间内的交易日列表。用户提到「交易日历」「A 股交易日」「港股交易日」「某区间内的交易日」「trading calendar」时使用。返回裸 JSON 对象（market/start_date/end_date/trade_dates），不使用通用 code/message/data 信封。
+---
+
+# 查询交易日历
+
+## 接口说明
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 查询交易日历 |
+| 外部接口 | GET /api/v1/market/data/time/trading-calendar |
+| 请求方式 | GET |
+| 适用场景 | 查询中国内地或香港市场在指定闭区间内的交易日列表 |
+
+## 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| market | string | 是 | 市场 | `cn` | 仅支持 `cn`（中国内地）/ `hk`（香港） |
+| start_date | int | 是 | 起始日期（含） | `20251001` | YYYYMMDD |
+| end_date | int | 是 | 截止日期（含） | `20251003` | YYYYMMDD；须 `>= start_date` |
+
+> 请求区间的起止日期必须全部位于所选市场的日历覆盖范围内：
+> - `cn`：2000-01-04 至 2026-12-31
+> - `hk`：2010-01-04 至 2026-12-31
+
+## 执行方式
+
+```bash
+# 查港股某区间交易日
+python <RUN_PY> trading-calendar --market hk --start_date 20251001 --end_date 20251003
+# 查 A 股某区间交易日
+python <RUN_PY> trading-calendar --market cn --start_date 20260101 --end_date 20260131
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。
+
+## 响应结构
+
+返回值为**裸 JSON 对象**，不使用通用的 `code/message/data` 响应信封。
+
+```json
+{
+  "market": "hk",
+  "start_date": 20251001,
+  "end_date": 20251003,
+  "trade_dates": [20251002, 20251003]
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| market | string | 请求的市场，`cn` 或 `hk` |
+| start_date | int | 请求的起始日期，YYYYMMDD |
+| end_date | int | 请求的截止日期，YYYYMMDD |
+| trade_dates | array&lt;int&gt; | 日期闭区间内按升序排列的交易日 |
+
+## 注意事项
+
+- `market` 仅支持 `cn` 和 `hk`，其他值返回 400。
+- `start_date` 不得晚于 `end_date`；区间须全部落在所选市场的日历覆盖范围内。
+- 响应直接是裸 JSON 对象，无 `code`/`message` 信封。

--- a/ftshare-market-data/sub-skills/trading-calendar/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/trading-calendar/scripts/handler.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""查询中国内地（cn）或香港（hk）市场在指定闭区间内的交易日列表"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+ENDPOINT = "/api/v1/market/data/time/trading-calendar"
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询交易日历")
+    parser.add_argument("--market", required=True, help="市场，仅支持 cn 或 hk")
+    parser.add_argument("--start_date", type=int, required=True, help="起始日期（含），YYYYMMDD")
+    parser.add_argument("--end_date", type=int, required=True, help="截止日期（含），YYYYMMDD")
+    args = parser.parse_args()
+
+    if args.market not in ("cn", "hk"):
+        print("错误：--market 仅支持 cn 或 hk", file=sys.stderr)
+        sys.exit(1)
+    if args.end_date < args.start_date:
+        print("错误：--start_date 不得晚于 --end_date", file=sys.stderr)
+        sys.exit(1)
+
+    qs = urllib.parse.urlencode({"market": args.market, "start_date": args.start_date, "end_date": args.end_date})
+    url = f"{BASE_URL}{ENDPOINT}?{qs}"
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/test_handlers_contract.py
+++ b/ftshare-market-data/test_handlers_contract.py
@@ -85,10 +85,10 @@ def test_every_handler_cli_flag_is_statically_discoverable(handler):
 
 
 def test_handler_inventory_and_cli_surface_are_fully_enumerated():
-    assert len(HANDLERS) == 153
+    assert len(HANDLERS) == 164
     flags = {flag for handler in HANDLERS for flag in _argument_flags(handler)}
-    assert len(flags) == 96
-    assert sum(len(_argument_flags(handler)) for handler in HANDLERS) == 491
+    assert len(flags) == 107
+    assert sum(len(_argument_flags(handler)) for handler in HANDLERS) == 549
 
 
 @pytest.mark.parametrize("handler", HANDLERS, ids=lambda path: path.parents[1].name)


### PR DESCRIPTION
- 新增: eastmoney-futures-strange, futures-eod-price, futures-kline-intraday, futures-kline-latest, member-build-process, member-position-ranking, trading-calendar, eastmoney-all-board-daily-ohlc, daec-ohlcs, report-announcement-list, report-announcement-summary。
- 能力总览新增「期货」域。子 skill 153→164, CLI flags 96→107, 总计 491→549。