### PR TITLE
feat: 适配基金基础信息与基金收益接口契约调整

### DIFF
--- a/ftshare-market-data/README.md
+++ b/ftshare-market-data/README.md
@@ -138,7 +138,7 @@ python run.py stock-ipos --all
 | **ETF** | `etf-description-all`、`etf-components-all`、`etf-pre-single`、`etf-pcfs`、`etf-adjust-factor`、`etf-minutes`、`etf-minutes-batch`、`etf-realtime-minute-kline`、`etf-realtime-day-kline` |
 | **基金** | `fund-basicinfo-single-fund`、`fund-cal-return-...`、`fund-nav-single-fund-paginated`、`fund-overview-all-funds-paginated`、`fund-support-symbols-all-funds-paginated` |
 | **指数** | `index-detail`、`index-list-paginated`、`index-ohlcs`、`index-prices`、`index-minutes`、`index-minutes-batch`、`sw-index-history-minutes`、`index-realtime-minute-kline`、`index-realtime-day-kline`、`index-description-all/paginated/download`、`index-weight-summary/list/download` |
-| **板块（东财 / 同花顺）** | `eastmoney-concept-boards`、`eastmoney-board-constituents/daily-ohlc/latest-ohlc`、`10jqk-board-list/kline/all-kline` |
+| **板块（东财 / 同花顺）** | `eastmoney-concept-boards`、`eastmoney-board-constituents/daily-ohlc/latest-ohlc`、`10jqk-board-list/kline/all-kline`、`ths-industry-constituents` |
 | **港股** | `company-hk`、`hk-candlesticks`、`northbound`、`southbound`、`eastmoney-hk-index-daily-kline`、`hsi-daily-weight` |
 | **美股** | `eastmoney-us-stock-list`、`eastmoney-us-stock-daily-ohlc`、`us-basic` |
 | **期货** | `futures-base-data`、`futures-lists`、`futures-limit`、`futures-settle`、`futures-weekly-detail`、`futures-warehouse-receipt`、`eastmoney-futures-position`、`eastmoney-futures-strange`、`member-build-process`、`member-position-ranking` |

--- a/ftshare-market-data/run.py
+++ b/ftshare-market-data/run.py
@@ -14,7 +14,7 @@ ftshare-market-data 统一调度入口。
     python run.py semantic-search-news --query 人工智能
     python run.py cb-lists
     python run.py etf-pcfs --date 20260309
-    python run.py fund-basicinfo-single-fund --institution-code 000001
+    python run.py fund-basicinfo-single-fund --fund-code 000001
     python run.py hk-candlesticks --trade-code 00700.HK --interval-unit day --until-date 2026-03-24 --since-date 2026-03-01 --limit 20
     python run.py index-weight-summary --page 1 --page-size 20
     python run.py index-weight-list --index-code 000300 --page 1 --page-size 20

--- a/ftshare-market-data/sub-skills/fund-basicinfo-single-fund/SKILL.md
+++ b/ftshare-market-data/sub-skills/fund-basicinfo-single-fund/SKILL.md
@@ -1,28 +1,31 @@
 ---
 name: fund-basicinfo-single-fund
-description: Get basic information of a specific fund by institution code. Use when user asks about fund details, 基金基本信息, 基金管理人, 基金经理, 基金类型, 投资目标.
+description: Get basic information of funds by fund code with pagination. Use when user asks about fund details, 基金基本信息, 基金管理人, 基金经理, 基金类型, 投资目标.
 ---
 
-# 查询指定基金基础信息
+# 查询基金基础信息（分页）
 
 ## 参数
 
 | 参数 | 类型 | 必填 | 说明 | 示例 |
 |------|------|------|------|------|
-| `--institution-code` | string | 是 | 6 位数字基金代码 | `000001` |
+| `--fund-code` | string | 否 | 6 位数字基金代码；不传时返回全市场数据的默认分页 | `000001` |
+| `--page` | int | 否 | 页码，从 1 开始（默认 1） | `1` |
+| `--page-size` | int | 否 | 每页记录数，默认 200，最大 500 | `200` |
 
 ## 用法
 
-通过主目录 `run.py` 调用（必填 `--institution-code`）：
+通过主目录 `run.py` 调用（所有参数均可选）：
 
 ```bash
-python <RUN_PY> fund-basicinfo-single-fund --institution-code 000001
+python <RUN_PY> fund-basicinfo-single-fund --fund-code 000001
+python <RUN_PY> fund-basicinfo-single-fund --page 1 --page-size 200
 ```
 
-`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出 JSON 对象，包含基金名称、管理人、经理、类型、投资理念/目标/范围、业绩基准等完整信息，按用户关注点展示。
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出分页 JSON（`items`/`page_num`/`page_size`/`total`/`pages`），`items` 中每项含 `fund_code`、`fund_name`、管理人、经理、类型、投资理念/目标/范围、业绩基准等完整字段，按用户关注点展示。
 
 ## 注意
 
-- `institution_code` 必须是 6 位数字
-- 响应为对象，不是分页列表
-- 若用户只给基金名称，建议先用 `fund-support-symbols-all-funds-paginated` 或 `fund-overview-all-funds-paginated` 查到对应 6 位 `institution-code` 再调用本接口。
+- `fund_code` 必须是 6 位数字；不传时查询全市场数据的默认分页
+- 响应为分页结构，基金档案在 `items` 数组中；需要全量数据时循环请求直到 `page > pages`
+- 若用户只给基金名称，建议先用 `fund-support-symbols-all-funds-paginated` 或 `fund-overview-all-funds-paginated` 查到对应 6 位 `fund-code` 再调用本接口。

--- a/ftshare-market-data/sub-skills/fund-basicinfo-single-fund/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/fund-basicinfo-single-fund/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""查询指定基金的基础信息"""
+"""查询基金基础信息（分页）"""
 import argparse
 import json
 import sys
@@ -42,11 +42,14 @@ def safe_urlopen(req_or_url):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="查询指定基金基础信息")
-    parser.add_argument("--institution-code", required=True, help="6 位数字基金代码，如 000001")
+    parser = argparse.ArgumentParser(description="查询基金基础信息（分页）")
+    parser.add_argument("--fund-code", default=None, help="6 位数字基金代码，如 000001；不传时返回全市场默认分页")
+    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始（默认 1）")
+    parser.add_argument("--page-size", type=int, default=None, help="每页记录数，默认 200，最大 500")
     args = parser.parse_args()
 
-    params = {"institution_code": args.institution_code}
+    params = {"fund_code": args.fund_code, "page": args.page, "page_size": args.page_size}
+    params = {key: value for key, value in params.items() if value is not None}
     url = f"{BASE_URL}/api/v1/market/data/fund/fund-basicinfo?" + urllib.parse.urlencode(params)
 
     try:

--- a/ftshare-market-data/sub-skills/fund-cal-return-single-fund-specific-period/SKILL.md
+++ b/ftshare-market-data/sub-skills/fund-cal-return-single-fund-specific-period/SKILL.md
@@ -9,15 +9,15 @@ description: Get cumulative return time series for a specific fund over a given 
 
 | 参数 | 类型 | 必填 | 说明 | 示例 |
 |------|------|------|------|------|
-| `--institution-code` | string | 是 | 6 位数字基金代码 | `159619` |
+| `--fund-code` | string | 是 | 6 位数字基金代码 | `159619` |
 | `--cal-type` | string | 是 | 区间类型：`1M` / `3M` / `6M` / `1Y` / `3Y` / `5Y` / `YTD` | `1Y` |
 
 ## 用法
 
-通过主目录 `run.py` 调用（必填 `--institution-code`、`--cal-type`）：
+通过主目录 `run.py` 调用（必填 `--fund-code`、`--cal-type`）：
 
 ```bash
-python <RUN_PY> fund-cal-return-single-fund-specific-period --institution-code 159619 --cal-type 1Y
+python <RUN_PY> fund-cal-return-single-fund-specific-period --fund-code 159619 --cal-type 1Y
 ```
 
 `<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出 JSON 数组，每项含 `date`（YYYYMMDD 整型）和 `return`（小数形式累计收益率），按时间序列展示。
@@ -27,4 +27,4 @@ python <RUN_PY> fund-cal-return-single-fund-specific-period --institution-code 1
 - 响应为数组，不是分页结构
 - `return` 为小数（如 0.0234 表示 2.34%），展示时可乘以 100 转为百分比
 - 区间选项：`1M`（近1月）、`3M`（近3月）、`6M`（近6月）、`1Y`（近1年）、`3Y`（近3年）、`5Y`（近5年）、`YTD`（今年来）
-- 若用户只给基金名称，建议先用 `fund-support-symbols-all-funds-paginated` 或 `fund-overview-all-funds-paginated` 查到对应 6 位 `institution-code` 再查询收益。
+- 若用户只给基金名称，建议先用 `fund-support-symbols-all-funds-paginated` 或 `fund-overview-all-funds-paginated` 查到对应 6 位 `fund-code` 再查询收益。

--- a/ftshare-market-data/sub-skills/fund-cal-return-single-fund-specific-period/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/fund-cal-return-single-fund-specific-period/scripts/handler.py
@@ -44,12 +44,12 @@ VALID_CAL_TYPES = ["1M", "3M", "6M", "1Y", "3Y", "5Y", "YTD"]
 def main():
     _require_api_key()
     parser = argparse.ArgumentParser(description="查询基金累计收益率")
-    parser.add_argument("--institution-code", required=True, help="6 位数字基金代码，如 159619")
+    parser.add_argument("--fund-code", required=True, help="6 位数字基金代码，如 159619")
     parser.add_argument("--cal-type", required=True, choices=VALID_CAL_TYPES,
                         help="区间类型：1M / 3M / 6M / 1Y / 3Y / 5Y / YTD")
     args = parser.parse_args()
 
-    params = {"institution_code": args.institution_code, "cal-type": args.cal_type}
+    params = {"fund_code": args.fund_code, "cal-type": args.cal_type}
     url = f"{BASE_URL}/api/v1/market/data/fund/fund-cal-return?" + urllib.parse.urlencode(params)
 
     try:

--- a/ftshare-market-data/sub-skills/fund-support-symbols-all-funds-paginated/SKILL.md
+++ b/ftshare-market-data/sub-skills/fund-support-symbols-all-funds-paginated/SKILL.md
@@ -20,7 +20,7 @@ description: Get paginated list of all supported fund symbols with code and name
 python <RUN_PY> fund-support-symbols-all-funds-paginated --page 1 --page-size 20
 ```
 
-`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出带分页信息的 JSON，每项含 `institution_code`（基金代码）和 `institution_name`（基金名称），以表格展示。
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出带分页信息的 JSON，每项含 `fund_code`（基金代码）和 `fund_name`（基金名称），以表格展示。
 
 ## 注意
 

--- a/ftshare-market-data/sub-skills/ths-industry-constituents/SKILL.md
+++ b/ftshare-market-data/sub-skills/ths-industry-constituents/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ths-industry-constituents
+description: 查询同花顺行业成分股列表。当用户需要查询指定同花顺行业的全部成分股代码和名称，或按股票代码/名称反查所属同花顺行业时使用。Use when user asks about 同花顺行业成分股, THS industry constituents, 行业成分关系.
+---
+
+# 查询同花顺行业成分股列表
+
+## 参数
+
+| 参数 | 类型 | 必填 | 说明 | 示例 |
+|------|------|------|------|------|
+| `--industry-code` | string | 否 | 同花顺行业代码，精确匹配 | `881157` |
+| `--industry-name` | string | 否 | 同花顺行业名称，精确匹配 | `证券` |
+| `--stock-code` | string | 否 | 股票代码，精确匹配 | `600905` |
+| `--stock-name` | string | 否 | 股票名称，精确匹配 | `三峡能源` |
+| `--page` | int | 否 | 页码，从 1 开始（默认 1） | `1` |
+| `--page-size` | int | 否 | 每页数量，默认 100，最大 1000 | `100` |
+
+筛选参数均为精确匹配，可单独或组合使用；均不传时返回最新一期全部行业成分关系。结果按 `industry_code`、`stock_code` 升序。
+
+## 用法
+
+通过主目录 `run.py` 调用（所有参数均可选）：
+
+```bash
+# 按行业名称查成分股
+python <RUN_PY> ths-industry-constituents --industry-name 证券
+
+# 按行业代码分页获取
+python <RUN_PY> ths-industry-constituents --industry-code 881157 --page 1 --page-size 1000
+
+# 按股票反查所属行业
+python <RUN_PY> ths-industry-constituents --stock-code 600905
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级的 `run.py` 绝对路径。脚本输出分页 JSON（`records`/`pageNum`/`pageSize`/`total`/`pages`），`records` 中每项含 `industry_code`、`industry_name`、`stock_code`、`stock_name`，以表格展示。
+
+## 注意
+
+- 接口始终返回数据源中的最新一期快照，无需传日期
+- 需要全量数据时，循环请求直到 `page > pages`
+- 筛选参数不能是空白字符串，否则服务端拒绝

--- a/ftshare-market-data/sub-skills/ths-industry-constituents/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/ths-industry-constituents/scripts/handler.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""查询同花顺行业成分股列表"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+SAFE_URLOPENER = urllib.request.build_opener()
+
+def _require_api_key():
+    key = os.environ.get("FTSHARE_API_KEY")
+    if not key:
+        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr)
+        raise SystemExit(2)
+    return key
+
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != urllib.parse.urlparse(BASE_URL).scheme or parsed.netloc != urllib.parse.urlparse(BASE_URL).netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(req_or_url, urllib.request.Request):
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    if isinstance(req_or_url, urllib.request.Request):
+        for key, value in _REQUEST_HEADERS.items():
+            req_or_url.add_unredirected_header(key, value)
+    else:
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+
+def main():
+    _require_api_key()
+    parser = argparse.ArgumentParser(description="查询同花顺行业成分股列表")
+    parser.add_argument("--industry-code", default=None, help="同花顺行业代码，精确匹配，如 881157")
+    parser.add_argument("--industry-name", default=None, help="同花顺行业名称，精确匹配，如 证券")
+    parser.add_argument("--stock-code", default=None, help="股票代码，精确匹配，如 600905")
+    parser.add_argument("--stock-name", default=None, help="股票名称，精确匹配，如 三峡能源")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始（默认 1）")
+    parser.add_argument("--page-size", type=int, default=100, help="每页数量，默认 100，最大 1000")
+    args = parser.parse_args()
+
+    params = {
+        "industry_code": args.industry_code,
+        "industry_name": args.industry_name,
+        "stock_code": args.stock_code,
+        "stock_name": args.stock_name,
+        "page": args.page,
+        "page_size": args.page_size,
+    }
+    params = {key: value for key, value in params.items() if value is not None}
+    url = f"{BASE_URL}/api/v1/market/data/ths-industry-constituents?" + urllib.parse.urlencode(params)
+
+    try:
+        with safe_urlopen(url) as resp:
+            data = json.loads(resp.read().decode())
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(body, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- fund-basicinfo 改为分页契约：--fund-code 改为可选，新增 --page/--page-size（单页最大 500），响应为 items 分页结构
- fund-cal-return 参数 --institution-code 改为 --fund-code
- fund-support-symbols SKILL.md 输出字段更新为 fund_code/fund_name
- run.py 示例同步更新
- 新增同花顺行业成分股列表接口