### PR TITLE
feat：同步 ftshare-doc 接口变更 - 新增 9 个子 skill 并调整 K 线与板块资金流契约

### DIFF
--- a/ftshare-market-data/README.md
+++ b/ftshare-market-data/README.md
@@ -130,18 +130,18 @@ python run.py stock-ipos --all
 | **A 股行情 / 基础** | `stock-list-all-stocks`、`stock-description-all`、`stock-quotes-list`、`stock-ipos`、`eastmoney-all-board-daily-ohlc`、`block-trades`、`margin-trading-details`、`continuous-auction-volume`、`intraday-auction-volume` |
 | **A 股财报 / 业绩** | `stock-income-*`、`stock-balance-*`、`stock-cashflow-*`、`stock-performance-express-*`、`stock-performance-forecast-*` |
 | **A 股股东 / 质押 / 增减持** | `stock-holder-ten`、`stock-holder-ften`、`stock-holder-nums`、`pledge-summary`、`pledge-detail`、`stock-share-chg`、`executive-holdings-changes`、`eastmoney-shareholder-changes` |
-| **A 股公司行动 / 代码与状态** | `shareholder-meeting`、`major-contract-by-date`、`major-contract-by-symbol`、`major-contract-summary`、`ashare-code-change`、`ashare-status-change` |
+| **A 股公司行动 / 代码与状态** | `shareholder-meeting`、`stock-dividends`、`stock-dividends-effective`、`major-contract-by-date`、`major-contract-by-symbol`、`major-contract-summary`、`ashare-code-change`、`ashare-status-change` |
 | **A 股估值 / 千股千评 / 热度 / 资金流** | `eastmoney-stock-valuation`、`eastmoney-market-valuation`、`stock-comment-index/score/org-participate/desire/focus`、`stock-rank-xueqiu`、`stock-rank-eastmoney`、`stock-capital-flows` |
 | **A 股涨跌停** | `limit-up-pool`、`limit-up-pool-yesterday`、`limit-down-pool` |
 | **A 股商誉** | `stock-goodwill-detail`、`stock-goodwill-impairment`、`stock-goodwill-industry`、`stock-goodwill-market-overview`、`stock-goodwill-predict` |
 | **可转债** | `cb-lists`、`cb-base-data` |
-| **ETF** | `etf-description-all`、`etf-components-all`、`etf-pre-single`、`etf-pcfs`、`etf-adjust-factor`、`etf-minutes`、`etf-minutes-batch`、`etf-realtime-minute-kline`、`etf-realtime-day-kline` |
+| **ETF** | `etf-description-all`、`etf-components-all`、`etf-component-details`、`etf-pre-single`、`etf-pcfs`、`etf-pcf-infos`、`etf-share`、`etf-net-value`、`etf-announcements`、`etf-adjust-factor`、`etf-candlesticks`、`etf-candlesticks-batch`、`etf-minutes`、`etf-minutes-batch`、`etf-realtime-minute-kline`、`etf-realtime-day-kline` |
 | **基金** | `fund-basicinfo-single-fund`、`fund-cal-return-...`、`fund-nav-single-fund-paginated`、`fund-overview-all-funds-paginated`、`fund-support-symbols-all-funds-paginated` |
-| **指数** | `index-detail`、`index-list-paginated`、`index-ohlcs`、`index-prices`、`index-minutes`、`index-minutes-batch`、`sw-index-history-minutes`、`index-realtime-minute-kline`、`index-realtime-day-kline`、`index-description-all/paginated/download`、`index-weight-summary/list/download` |
+| **指数** | `index-detail`、`index-list-paginated`、`index-ohlcs`、`index-prices`、`index-candlesticks`、`index-candlesticks-batch`、`index-minutes`、`index-minutes-batch`、`sw-index-history-minutes`、`index-realtime-minute-kline`、`index-realtime-day-kline`、`index-description-all/paginated/download`、`index-weight-summary/list/download` |
 | **板块（东财 / 同花顺）** | `eastmoney-concept-boards`、`eastmoney-board-constituents/daily-ohlc/latest-ohlc`、`10jqk-board-list/kline/all-kline`、`ths-industry-constituents` |
 | **港股** | `company-hk`、`hk-candlesticks`、`northbound`、`southbound`、`eastmoney-hk-index-daily-kline`、`hsi-daily-weight` |
 | **美股** | `eastmoney-us-stock-list`、`eastmoney-us-stock-daily-ohlc`、`us-basic` |
-| **期货** | `futures-base-data`、`futures-lists`、`futures-limit`、`futures-settle`、`futures-weekly-detail`、`futures-warehouse-receipt`、`eastmoney-futures-position`、`eastmoney-futures-strange`、`member-build-process`、`member-position-ranking` |
+| **期货** | `futures-base-data`、`futures-lists`、`futures-limit`、`futures-settle`、`futures-weekly-detail`、`futures-warehouse-receipt`、`futures-contract-kline`、`eastmoney-futures-position`、`eastmoney-futures-strange`、`member-build-process`、`member-position-ranking` |
 | **宏观经济（中国 + 美国）** | `economic-china-gdp/cpi/ppi/pmi/lpr/...-monthly`（15 项）、`economic-us-economic-by-type`（16 类，按 `--type`） |
 
 ## 名称 → 代码映射

--- a/ftshare-market-data/SKILL.md
+++ b/ftshare-market-data/SKILL.md
@@ -33,8 +33,16 @@ python <RUN_PY> etf-realtime-day-kline --symbols 510300.SH
 python <RUN_PY> index-minutes --symbol 000300.SH --since-ts-millis 1787189400000 --until-ts-millis 1787191200000
 python <RUN_PY> stock-reports --stock-code 600036.SH --page 1 --page-size 20
 python <RUN_PY> stock-announcements --stock-code 600000 --page 1 --page-size 20
-python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,510300.SH --interval-unit Day --until-ts-millis 1787191200000
-python <RUN_PY> etf-minutes-batch --symbols 510300.SH,159915.SZ --since-ts-millis 1787189400000 --until-ts-millis 1787191200000
+python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,510300.SH --interval-unit Day --since-ts-millis 1787000000000 --until-ts-millis 1787191200000
+python <RUN_PY> etf-candlesticks-batch --symbols 510300.XSHG,159915.XSHE --interval-unit Day --since-ts-millis 1787000000000 --until-ts-millis 1787191200000
+python <RUN_PY> index-candlesticks-batch --symbols 000300.XSHG,399001.XSHE --interval-unit Day --since-ts-millis 1787000000000 --until-ts-millis 1787191200000
+python <RUN_PY> futures-contract-kline --symbol A2605.DCE --interval daily --limit 5
+python <RUN_PY> etf-pcf-infos --symbol 510300.SH --trade-date 20260909
+python <RUN_PY> etf-net-value --etf-code 510300 --nav-date 20260909
+python <RUN_PY> etf-share --etf-code 510300 --page 1 --page-size 5
+python <RUN_PY> etf-announcements --etf-code 159915 --page 1 --page-size 5
+python <RUN_PY> etf-component-details --symbol 510300.SH
+python <RUN_PY> stock-dividends-effective --symbol 600519.XSHG --page 1 --page-size 20
 python <RUN_PY> executive-holdings-changes --stock-code 600519 --page 1 --page-size 20
 python <RUN_PY> eastmoney-shareholder-changes --symbol 股东增持 --page 1 --page-size 20
 python <RUN_PY> ashare-code-change --trade-code 001872.SZ

--- a/ftshare-market-data/sub-skills/eastmoney-sector-flow/SKILL.md
+++ b/ftshare-market-data/sub-skills/eastmoney-sector-flow/SKILL.md
@@ -1,16 +1,50 @@
 ---
 name: eastmoney-sector-flow
-description: 查询东方财富板块资金流。接口：GET /api/v1/market/data/eastmoney-sector-flow。所有请求必须设置 FTSHARE_API_KEY。
+description: 查询东方财富板块资金流（行业/概念/地域日资金流）。用户问东财板块资金流、板块主力净流入、行业/概念/地域资金流向、BK 板块代码资金流、超大单大单净流入时使用。
 ---
 
 # 东方财富板块资金流
 
-接口：GET `/api/v1/market/data/eastmoney-sector-flow`。参数和响应以 `ftshare-doc/api-doc/股票数据/资金流向数据/东方财富板块资金流.md` 为准。
+## 1. 接口描述
 
-请求必须从环境变量 `FTSHARE_API_KEY` 读取凭据，并通过请求头发送 `FTSHARE_API_KEY` 和 `Content-Type: application/json`；缺少凭据时不会发起请求。
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 东方财富板块资金流（get_eastmoney_sector_flow） |
+| 外部接口 | `GET /api/v1/market/data/eastmoney-sector-flow` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 获取东方财富板块（行业/概念/地域）日资金流，含主力/超大单/大单/中单/小单净流入及净占比；支持按板块代码、板块类型、行业层级、交易日或日期区间过滤 |
 
-## 调用示例
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| board_code | string | 否 | 板块代码 | BK0488 | 东财板块代码，BK 开头 |
+| board_type | string | 否 | 板块类型 | industry | industry（行业）/ concept（概念）/ regional（地域） |
+| board_level | int | 否 | 行业层级 | 2 | 1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry |
+| trade_date | string | 否 | 交易日 | 20260623 | YYYYMMDD |
+| start_date | string | 否 | 区间起始日 | 20260601 | YYYYMMDD |
+| end_date | string | 否 | 区间结束日 | 20260630 | YYYYMMDD |
+| page | int | 否 | 页码 | 1 | 从 1 开始，默认 1 |
+| page_size | int | 否 | 每页条数 | 50 | 默认 50，最大 500 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为分页对象：`pageNum` / `pageSize` / `total` / `pages` / `records`。
+
+records 元素核心字段：`board_code`、`board_name`、`board_type`（industry/concept/regional）、`board_level`（industry 为 1/2/3，concept/regional 为 0）、`trade_date`（YYYYMMDD），以及 `main_net`/`main_pct`、`super_large_net`/`super_large_pct`、`large_net`/`large_pct`、`medium_net`/`medium_pct`、`small_net`/`small_pct`（净流入单位亿元，净占比单位 %）。
+
+## 4. 调用方式
 
 ```bash
-python <RUN_PY> eastmoney-sector-flow --page 1 --sector_name 1 --super_large_net 1 --super_large_pct 1 --medium_net 1 --medium_pct 1
+python <RUN_PY> eastmoney-sector-flow --board-type industry --board-level 2 --page 1 --page-size 5
+python <RUN_PY> eastmoney-sector-flow --board-code BK0488 --trade-date 20260623
+python <RUN_PY> eastmoney-sector-flow --board-type concept --start-date 20260601 --end-date 20260630
 ```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 请求参数为 `board_code` / `board_type` / `board_level`（原 `sector_code` / `sector_type` / `sector_level` 已更名，不再使用旧参数名）。
+- 概念和地域板块的层级为 0，传入 `board_level` 时不会匹配 concept/regional 数据。
+- `trade_date`、`start_date`、`end_date` 可同时使用，按全部条件过滤。

--- a/ftshare-market-data/sub-skills/eastmoney-sector-flow/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/eastmoney-sector-flow/scripts/test_handler.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Tests for eastmoney-sector-flow handler (board_* parameter rename)"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            handler.main()
+
+
+class TestBoardParams(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_board_params_sent(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--board-code", "BK0488", "--board-type", "industry",
+              "--board-level", "2", "--page", "1", "--page-size", "5"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v1/market/data/eastmoney-sector-flow", req.full_url)
+        self.assertIn("board_code=BK0488", req.full_url)
+        self.assertIn("board_type=industry", req.full_url)
+        self.assertIn("board_level=2", req.full_url)
+        self.assertNotIn("sector_code", req.full_url)
+        self.assertNotIn("sector_type", req.full_url)
+        self.assertNotIn("sector_level", req.full_url)
+
+    def test_rejects_unknown_board_type(self):
+        with self.assertRaises(SystemExit):
+            _run(["--board-type", "unknown"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_all_params_optional(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run([])
+        req = mock_open.call_args[0][0]
+        self.assertTrue(req.full_url.endswith("/api/v1/market/data/eastmoney-sector-flow"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/etf-announcements/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-announcements/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: etf-announcements
+description: 查询 ETF 公告列表（etf_announcements）。用户问 ETF 公告、基金公告、ETF 中期报告/年报公告、按日期查全市场 ETF 公告、公告 PDF 下载地址时使用。
+---
+
+# ETF 公告列表
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | ETF 公告列表（etf_announcements） |
+| 外部接口 | `GET /api/v2/market/data/announcements/etf-announcements` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按标的查单只 ETF 全部公告，或按单日日期查全市场 ETF 公告；公告正文 PDF 可按返回的 `url_hash` 另行下载 |
+
+两种模式二选一：
+
+1. **按标的**：传 `etf_code`，查单只 ETF 所有公告。
+2. **按日期**：传 `start_date`（必须等于 `end_date`，仅支持单日），查指定日期全市场 ETF 公告。
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| etf_code | string | 二选一 | ETF 代码 | 159915 | 支持裸代码/短后缀/长后缀（`159915.SZ`、`510300.XSHG`），大小写不敏感 |
+| start_date | string | 二选一 | 日期 | 20260831 | YYYYMMDD；按日期查询时必填，仅支持单日 |
+| end_date | string | 否 | 日期 | 20260831 | 不填默认等于 `start_date`，且必须等于 `start_date` |
+| page | int | 是 | 页码 | 1 | 必填 |
+| page_size | int | 是 | 每页条数 | 5 | 必填 |
+| --all | - | 否 | 自动翻页拉全量 | - | 仅本子 skill 扩展参数 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为分页对象：`pageNum` / `pageSize` / `total` / `pages` / `records`。
+
+records 元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| etf_code | string | ETF 代码，6 位裸代码，不带交易所后缀 |
+| etf_name | string | ETF 名称 |
+| announcement_id | string | 公告 id |
+| announcement_title | string | 公告标题 |
+| announcement_time | string | 公告时间，格式 YYYY-MM-DD HH:MM:SS |
+| url_hash | string | 公告文件 URL 哈希，用于下载正文文件 |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-announcements --etf-code 159915 --page 1 --page-size 5
+python <RUN_PY> etf-announcements --start-date 20260831 --page 1 --page-size 20
+python <RUN_PY> etf-announcements --etf-code 159915 --page 1 --page-size 20 --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 必须提供 `etf_code` 或 `start_date` 之一，否则服务端报错（handler 会本地校验并拒绝）。
+- 按日期查询仅支持单日：`end_date` 不填默认等于 `start_date`，填了则必须相等。
+- ETF 范围为场内 ETF，不含联接基金、LOF。
+- 公告正文下载：`GET /api/v2/market/data/announcements/etf-announcements/{url_hash}`，响应为 PDF 二进制附件；`url_hash` 须取自本接口返回值，勿硬编码。
+- 当前数据源仅覆盖深市 ETF（`159` 开头）；查询沪市代码会返回空列表。

--- a/ftshare-market-data/sub-skills/etf-announcements/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-announcements/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""东方财富板块资金流（GET /api/v1/market/data/eastmoney-sector-flow）"""
+"""ETF 公告列表（GET /api/v2/market/data/announcements/etf-announcements）"""
 import argparse
 import json
 import sys
@@ -20,9 +20,7 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v1/market/data/eastmoney-sector-flow"
-
-BOARD_TYPES = ("industry", "concept", "regional")
+ENDPOINT = "/api/v2/market/data/announcements/etf-announcements"
 
 HEADERS = {
     "X-Client-Name": "ft-claw",
@@ -51,30 +49,20 @@ def safe_urlopen(req_or_url):
 
 
 def build_params(args):
-    params = {}
-    if args.board_code is not None:
-        params["board_code"] = args.board_code
-    if args.board_type is not None:
-        params["board_type"] = args.board_type
-    if args.board_level is not None:
-        params["board_level"] = args.board_level
-    if args.trade_date is not None:
-        params["trade_date"] = args.trade_date
+    params = {"page": args.page, "page_size": args.page_size}
+    if args.etf_code is not None:
+        params["etf_code"] = args.etf_code
     if args.start_date is not None:
         params["start_date"] = args.start_date
     if args.end_date is not None:
         params["end_date"] = args.end_date
-    if args.page is not None:
-        params["page"] = args.page
-    if args.page_size is not None:
-        params["page_size"] = args.page_size
     return params
 
 
-def fetch(params):
-    query = ("?" + urllib.parse.urlencode(params)) if params else ""
+def fetch_page(params):
+    query = urllib.parse.urlencode(params)
     req = urllib.request.Request(
-        f"{BASE_URL}{ENDPOINT}{query}",
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,22 +79,42 @@ def fetch(params):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="东方财富板块（行业/概念/地域）日资金流")
-    parser.add_argument("--board-code", dest="board_code", default=None,
-                        help="板块代码，如 BK0488")
-    parser.add_argument("--board-type", dest="board_type", default=None, choices=BOARD_TYPES,
-                        help="板块类型：industry（行业）/concept（概念）/regional（地域）")
-    parser.add_argument("--board-level", dest="board_level", type=int, default=None,
-                        help="行业层级：1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry")
-    parser.add_argument("--trade-date", dest="trade_date", default=None, help="交易日 YYYYMMDD")
-    parser.add_argument("--start-date", dest="start_date", default=None, help="区间起始日 YYYYMMDD")
-    parser.add_argument("--end-date", dest="end_date", default=None, help="区间结束日 YYYYMMDD")
-    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1")
-    parser.add_argument("--page-size", dest="page_size", type=int, default=None,
-                        help="每页条数，默认 50，最大 500")
+    parser = argparse.ArgumentParser(
+        description="ETF 公告列表：按标的（--etf-code）或按单日日期（--start-date）查询"
+    )
+    parser.add_argument("--etf-code", dest="etf_code", default=None,
+                        help="ETF 代码，支持裸代码/短后缀/长后缀，如 159915、159915.SZ、510300.XSHG")
+    parser.add_argument("--start-date", dest="start_date", default=None,
+                        help="日期 YYYYMMDD（按日期查询时必填，仅支持单日）")
+    parser.add_argument("--end-date", dest="end_date", default=None,
+                        help="日期 YYYYMMDD；不填默认等于 start_date，且必须等于 start_date")
+    parser.add_argument("--page", type=int, required=True, help="页码（必填）")
+    parser.add_argument("--page-size", dest="page_size", type=int, required=True, help="每页条数（必填）")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
     args = parser.parse_args()
 
-    print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
+    if args.etf_code is None and args.start_date is None:
+        print("必须提供 --etf-code（按标的查）或 --start-date（按日期查）", file=sys.stderr)
+        raise SystemExit(2)
+
+    params = build_params(args)
+    if args.fetch_all:
+        first = fetch_page(params)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        total_pages = data.get("pages") or 1
+        for page in range(2, total_pages + 1):
+            page_data = fetch_page({**params, "page": page})
+            records.extend((page_data.get("data") or {}).get("records", []))
+        result = {
+            "records": records,
+            "pages": total_pages,
+            "total": data.get("total", len(records)),
+        }
+    else:
+        result = fetch_page(params)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
 
 
 if __name__ == "__main__":

--- a/ftshare-market-data/sub-skills/etf-announcements/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/etf-announcements/scripts/test_handler.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for etf-announcements handler"""
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            with patch("sys.stdout", new_callable=StringIO) as out:
+                handler.main()
+                return json.loads(out.getvalue())
+
+
+class TestModes(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_requires_code_or_date(self):
+        with self.assertRaises(SystemExit):
+            _run(["--page", "1", "--page-size", "5"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_by_symbol(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = (
+            b'{"code":200,"data":{"records":[],"pages":1,"total":0}}'
+        )
+        _run(["--etf-code", "159915", "--page", "1", "--page-size", "5"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v2/market/data/announcements/etf-announcements", req.full_url)
+        self.assertIn("etf_code=159915", req.full_url)
+        self.assertIn("page=1", req.full_url)
+        self.assertIn("page_size=5", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_by_single_date(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = (
+            b'{"code":200,"data":{"records":[],"pages":1,"total":0}}'
+        )
+        _run(["--start-date", "20260831", "--page", "1", "--page-size", "5"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("start_date=20260831", req.full_url)
+        self.assertNotIn("end_date", req.full_url)
+
+
+class TestFetchAll(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_all_aggregates_pages(self, mock_open):
+        page1 = {"code": 200, "data": {"records": [{"announcement_id": "1"}], "pages": 2, "total": 2}}
+        page2 = {"code": 200, "data": {"records": [{"announcement_id": "2"}], "pages": 2, "total": 2}}
+        mock_open.return_value.__enter__.return_value.read.side_effect = [
+            json.dumps(page1).encode(), json.dumps(page2).encode(),
+        ]
+        result = _run(["--etf-code", "159915", "--page", "1", "--page-size", "1", "--all"])
+        self.assertEqual([r["announcement_id"] for r in result["records"]], ["1", "2"])
+        self.assertEqual(result["total"], 2)
+        second_req = mock_open.call_args_list[1][0][0]
+        self.assertIn("page=2", second_req.full_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/etf-candlesticks-batch/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-candlesticks-batch/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: etf-candlesticks-batch
+description: 批量查询多只 ETF 的历史 K 线（etf_candlesticks_batch）。用户问多只 ETF 日/周/月/年 K 线、批量 ETF 开高低收、ETF 批量行情、多 ETF 对比 K 线时使用。
+---
+
+# 批量ETFK线
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 批量ETFK线（etf_candlesticks_batch） |
+| 外部接口 | `GET /api/v2/market/data/etf-candlesticks/batch` |
+| 请求方式 | GET（query 参数，`symbols` 可重复传入） |
+| 适用场景 | 一次批量获取多只 ETF 的历史 K 线（开高低收、成交量、成交额、换手率），支持日/周/月/年周期与前复权/后复权 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbols | string[] | 是 | ETF 代码列表，逗号分隔传给 CLI | 510300.SH,159915.SZ | 沪市支持 `.XSHG`/`.SH`，深市支持 `.XSHE`/`.SZ`；接口侧以重复 query 参数发送 |
+| interval_unit | string | 是 | 周期单位 | Day | Day/Week/Month/Year，大小写不敏感；**不支持 Minute** |
+| adjust_kind | string | 否 | 复权类型 | Forward | None（默认）/Forward（前复权）/Backward（后复权） |
+| since_ts_millis | int | 是 | 开始时间戳（毫秒） | 1756431000000 | 与 until 的跨度不得超过 12 个日历月；不得晚于 until |
+| until_ts_millis | int | 是 | 结束时间戳（毫秒） | 1756791000000 | - |
+| limit | int | 否 | 每个标的返回条数上限 | 2 | 不传时返回请求时间范围内的全部数据 |
+
+## 3. 响应说明
+
+外层固定为 `code`（成功 200）/ `message`（成功 `success`）/ `data`（失败时为 `null`）。`data` 为非分页嵌套数组，外层每项为 `[symbol, K线数组]`，每根 K 线字段：
+
+| 字段名 | 类型 | 说明 | 单位 |
+|--------|------|------|------|
+| symbol | string | ETF 代码，响应统一使用 `.SH`、`.SZ` 短后缀 | - |
+| open / high / low / close | number | 开/高/低/收盘价 | 元 |
+| ts_millis | string | 收盘时间戳 | 毫秒 |
+| ts_millis_open | string | 开盘时间戳 | 毫秒 |
+| turnover | number | 成交额 | 元 |
+| volume | integer | 成交量 | - |
+| turnover_rate | number | 换手率；ETF 标的当前为 `null` | % |
+
+注：`open/high/low/close`、`turnover` 在 JSON 中实际以字符串返回（避免精度丢失）；`ts_millis` 为数字。
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-candlesticks-batch --symbols 510300.SH,159915.SZ --interval-unit Day --since-ts-millis 1756431000000 --until-ts-millis 1756791000000 --limit 2
+python <RUN_PY> etf-candlesticks-batch --symbols 510300.XSHG,159915.XSHE --interval-unit Week --adjust-kind Forward --since-ts-millis 1754092800000 --until-ts-millis 1756791000000
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- `symbols`、`interval_unit`、`since_ts_millis`、`until_ts_millis` 必填；所有 `symbols` 使用相同周期。
+- 接口仅支持 GET；`symbols` 在查询参数中以重复参数形式发送（`symbols=510300.SH&symbols=159915.SZ`）。
+- 时间跨度最多 12 个日历月；需要更长历史时按窗口分段多次调用。
+- 不支持分钟 K 线；分钟数据请使用 `etf-minutes-batch` 子 skill。
+- `symbols` 中每项必须是 ETF 标的：若混入非 ETF（如股票），整个批量请求失败，不静默过滤（当前返回系统错误）。
+- 输入 `.XSHG`/`.XSHE` 长后缀时，响应中的 symbol 会规范化为 `.SH`、`.SZ` 短后缀。
+- 默认不复权（None）；仅使用历史日 K 数据计算，不含实时行情，实际起始日期以行情数据源覆盖为准。

--- a/ftshare-market-data/sub-skills/etf-candlesticks-batch/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-candlesticks-batch/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""批量查询多只标的 K 线（GET /api/v2/market/data/stock-candlesticks/batch）"""
+"""批量查询多只 ETF K 线（GET /api/v2/market/data/etf-candlesticks/batch）"""
 import argparse
 import json
 import sys
@@ -20,10 +20,15 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v2/market/data/stock-candlesticks/batch"
+ENDPOINT = "/api/v2/market/data/etf-candlesticks/batch"
 
 INTERVAL_UNITS = ("Day", "Week", "Month", "Year")
 ADJUST_KINDS = ("None", "Forward", "Backward")
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
 
 
 def safe_urlopen(req_or_url):
@@ -46,12 +51,6 @@ def safe_urlopen(req_or_url):
     return SAFE_URLOPENER.open(req_or_url)
 
 
-HEADERS = {
-    "X-Client-Name": "ft-claw",
-    "Content-Type": "application/json",
-}
-
-
 def parse_symbols(raw):
     syms = [s.strip() for s in raw.split(",") if s.strip()]
     if not syms:
@@ -60,8 +59,7 @@ def parse_symbols(raw):
     return syms
 
 
-def build_body(symbols, interval_unit, adjust_kind,
-               since_ts_millis, until_ts_millis, limit):
+def build_query(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit):
     body = {
         "symbols": symbols,
         "interval_unit": interval_unit,
@@ -76,14 +74,11 @@ def build_body(symbols, interval_unit, adjust_kind,
     return body
 
 
-def fetch(symbols, interval_unit, adjust_kind,
-          since_ts_millis, until_ts_millis, limit):
-    body = build_body(symbols, interval_unit, adjust_kind,
-                      since_ts_millis, until_ts_millis, limit)
+def fetch(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit):
+    body = build_query(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit)
     query = urllib.parse.urlencode(body, doseq=True)
-    url = f"{BASE_URL}{ENDPOINT}?{query}"
     req = urllib.request.Request(
-        url,
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,8 +86,7 @@ def fetch(symbols, interval_unit, adjust_kind,
         with safe_urlopen(req) as resp:
             return json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
-        msg = e.read().decode()
-        print(f"HTTP {e.code}: {msg}", file=sys.stderr)
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
         sys.exit(1)
     except urllib.error.URLError as e:
         print(f"Request failed: {e}", file=sys.stderr)
@@ -101,9 +95,9 @@ def fetch(symbols, interval_unit, adjust_kind,
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="批量查询多只标的 K 线（GET 查询参数）")
+    parser = argparse.ArgumentParser(description="批量获取多只 ETF 的历史 K 线（不支持分钟周期）")
     parser.add_argument("--symbols", required=True,
-                        help="标的代码列表，逗号分隔，如 600519.SH,510300.SH,113027.SH,000300.SH；支持长短后缀混用")
+                        help="ETF 代码列表，逗号分隔，如 510300.XSHG,159915.XSHE；也接受 .SH/.SZ 短后缀")
     parser.add_argument("--interval-unit", dest="interval_unit", required=True, type=str.capitalize,
                         choices=INTERVAL_UNITS, help="K 线周期：Day/Week/Month/Year（大小写不敏感，不支持 Minute）")
     parser.add_argument("--adjust-kind", dest="adjust_kind", default="None",
@@ -121,8 +115,8 @@ def main():
         raise SystemExit(2)
 
     symbols = parse_symbols(args.symbols)
-    data = fetch(symbols, args.interval_unit,
-                 args.adjust_kind, args.since_ts_millis, args.until_ts_millis, args.limit)
+    data = fetch(symbols, args.interval_unit, args.adjust_kind,
+                 args.since_ts_millis, args.until_ts_millis, args.limit)
     print(json.dumps(data, ensure_ascii=False, indent=2))
 
 

--- a/ftshare-market-data/sub-skills/etf-candlesticks-batch/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/etf-candlesticks-batch/scripts/test_handler.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Tests for stock-candlesticks-batch handler"""
+"""Tests for etf-candlesticks-batch handler"""
 import json
 import os
 import sys
 import unittest
-import urllib.error
-from io import BytesIO, StringIO
+from io import StringIO
 from unittest.mock import patch
 import importlib.util
 
@@ -17,22 +16,30 @@ SINCE = "1756431000000"
 UNTIL = "1756791000000"
 
 
-class TestBuildBody(unittest.TestCase):
+class TestBuildQuery(unittest.TestCase):
     def setUp(self):
         spec.loader.exec_module(handler)
 
     def test_required_only(self):
-        body = handler.build_body(["600519.SH"], "Day", "None", 1756431000000, 1756791000000, None)
-        self.assertEqual(body["symbols"], ["600519.SH"])
+        body = handler.build_query(["510300.SH"], "Day", "None", 1756431000000, 1756791000000, None)
+        self.assertEqual(body["symbols"], ["510300.SH"])
         self.assertEqual(body["interval_unit"], "Day")
         self.assertEqual(body["since_ts_millis"], 1756431000000)
+        self.assertEqual(body["until_ts_millis"], 1756791000000)
         self.assertNotIn("adjust_kind", body)
         self.assertNotIn("limit", body)
         self.assertNotIn("interval_value", body)
 
+    def test_optional_fields(self):
+        body = handler.build_query(["510300.SH", "159915.SZ"], "Week", "Forward",
+                                   1756700000000, 1756791000000, 5)
+        self.assertEqual(body["symbols"], ["510300.SH", "159915.SZ"])
+        self.assertEqual(body["adjust_kind"], "Forward")
+        self.assertEqual(body["limit"], 5)
+
     def test_minute_not_allowed(self):
         with self.assertRaises(SystemExit):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "510300.SH",
                                             "--interval-unit", "Minute",
                                             "--since-ts-millis", SINCE,
                                             "--until-ts-millis", UNTIL]):
@@ -44,24 +51,18 @@ class TestFetch(unittest.TestCase):
         spec.loader.exec_module(handler)
 
     @patch.object(handler, "safe_urlopen")
-    def test_get_to_stock_batch_endpoint(self, mock_open):
+    def test_query_string_expands_symbols(self, mock_open):
         mock_open.return_value.__enter__.return_value.read.return_value = b"[]"
-        handler.fetch(["600519.SH", "000001.SZ"], "Day", "None",
-                      1756431000000, 1756791000000, 2)
+        handler.fetch(["510300.SH", "159915.SZ"], "Day", "None", 1756431000000, 1756791000000, 2)
         req = mock_open.call_args[0][0]
         self.assertEqual(req.get_method(), "GET")
-        self.assertIn("/api/v2/market/data/stock-candlesticks/batch", req.full_url)
-        self.assertIn("since_ts_millis=1756431000000", req.full_url)
-        self.assertIsNone(req.data)
+        self.assertIn("/api/v2/market/data/etf-candlesticks/batch", req.full_url)
+        query = req.full_url.split("?", 1)[1]
+        self.assertIn("symbols=510300.SH", query)
+        self.assertIn("symbols=159915.SZ", query)
+        self.assertIn("interval_unit=Day", query)
+        self.assertIn("since_ts_millis=1756431000000", query)
         self.assertEqual(req.headers.get("X-client-name"), "ft-claw")
-
-    @patch.object(handler, "safe_urlopen")
-    def test_http_error_exits(self, mock_open):
-        mock_open.side_effect = urllib.error.HTTPError(
-            "https://fake", 500, "Internal Error", {}, BytesIO(b"server error")
-        )
-        with self.assertRaises(SystemExit):
-            handler.fetch(["600519.SH"], "Day", "None", 1756431000000, 1756791000000, None)
 
 
 class TestMain(unittest.TestCase):
@@ -70,20 +71,23 @@ class TestMain(unittest.TestCase):
 
     @patch.object(handler, "safe_urlopen")
     def test_main_emits_json(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b"[]"
+        mock_open.return_value.__enter__.return_value.read.return_value = (
+            b'{"code":200,"message":"success","data":[["510300.SH",'
+            b'[{"open":4.55,"close":4.601,"ts_millis":"1756450800000"}]]]}'
+        )
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", [
-                "handler.py", "--symbols", "600519.SH,000001.SZ",
-                "--interval-unit", "Day",
-                "--since-ts-millis", SINCE, "--until-ts-millis", UNTIL
-            ]):
-                with patch("sys.stdout", new_callable=StringIO) as fake_out:
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "510300.SH",
+                                            "--interval-unit", "Day",
+                                            "--since-ts-millis", SINCE,
+                                            "--until-ts-millis", UNTIL, "--limit", "2"]):
+                with patch("sys.stdout", new_callable=StringIO) as out:
                     handler.main()
-                    self.assertEqual(json.loads(fake_out.getvalue()), [])
+                    data = json.loads(out.getvalue())
+                    self.assertEqual(data["data"][0][0], "510300.SH")
 
     def test_main_requires_since(self):
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "510300.SH",
                                             "--interval-unit", "Day",
                                             "--until-ts-millis", UNTIL]):
                 with self.assertRaises(SystemExit):
@@ -91,24 +95,20 @@ class TestMain(unittest.TestCase):
 
     def test_main_rejects_since_after_until(self):
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "510300.SH",
                                             "--interval-unit", "Day",
                                             "--since-ts-millis", UNTIL,
                                             "--until-ts-millis", SINCE]):
                 with self.assertRaises(SystemExit):
                     handler.main()
 
-    @patch.object(handler, "safe_urlopen")
-    def test_interval_unit_case_insensitive(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+    def test_main_requires_symbols(self):
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
-                                            "--interval-unit", "day",
+            with patch.object(sys, "argv", ["handler.py", "--interval-unit", "Day",
                                             "--since-ts-millis", SINCE,
                                             "--until-ts-millis", UNTIL]):
-                handler.main()
-        req = mock_open.call_args[0][0]
-        self.assertIn("interval_unit=Day", req.full_url)
+                with self.assertRaises(SystemExit):
+                    handler.main()
 
 
 if __name__ == "__main__":

--- a/ftshare-market-data/sub-skills/etf-component-details/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-component-details/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: etf-component-details
+description: 查询 ETF 成分证券明细（etf_component_details）。用户问 ETF 成分股明细、申赎清单成分证券、成分数量、现金替代标志、必须/禁止现金替代、ETF PCF 成分明细时使用。
+---
+
+# ETF 成分证券明细
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | ETF 成分证券明细（etf_component_details） |
+| 外部接口 | `GET /api/v2/market/data/etf-component-details` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按 ETF 和交易日返回申赎清单中的全部成分证券及数量、成分类型、现金替代标志与替代金额 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 是 | ETF 代码 | 510300.SH | 也支持 `159915.SZ` |
+| trade_date | int | 否 | 交易日 | 20260908 | YYYYMMDD；不传时查询该 ETF 最新可用交易日 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为成分证券明细数组（无分页，一次返回全部）。
+
+数组元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| symbol | string | ETF 代码 |
+| trade_date | int | 实际返回的交易日 YYYYMMDD |
+| component_code | string | 成分证券代码，带 `.SH`/`.SZ`/`.BJ`/`.HK` 后缀 |
+| component_name | string | 成分证券名称 |
+| component_type | string / null | `stock`/`bond`/`commodity`/`cash`；无法识别时为 `null` |
+| quantity | int / null | 成分证券数量（股） |
+| cash_substitution_flag | int / null | 现金替代原始编码 |
+| cash_substitution_type | string / null | `prohibited`/`allowed`/`mandatory`/`refund` |
+| creation_substitution_amount | number / null | 申购替代金额 |
+| redemption_substitution_amount | number / null | 赎回替代金额 |
+| general_substitution_amount | number / null | 通用替代金额 |
+
+现金替代编码：`0`=prohibited（禁止现金替代）、`1`=allowed（允许）、`2/4/6/8`=mandatory（必须）、`3/5/7`=refund（退补）。
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-component-details --symbol 510300.SH
+python <RUN_PY> etf-component-details --symbol 510300.SH --trade-date 20260908
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 数据范围 20250501 年至今。
+- `trade_date` 为精确查询条件：该日期没有数据时成功返回空数组，不向前回退。
+- 现金占位成分会保留，`component_type` 标记为 `cash`。
+- 不同交易所的现金替代编码语义可能存在差异；需要精确区分时以 `cash_substitution_flag` 为准。
+- 本接口不返回成分权重。

--- a/ftshare-market-data/sub-skills/etf-component-details/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-component-details/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""东方财富板块资金流（GET /api/v1/market/data/eastmoney-sector-flow）"""
+"""ETF 成分证券明细（GET /api/v2/market/data/etf-component-details）"""
 import argparse
 import json
 import sys
@@ -20,9 +20,7 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v1/market/data/eastmoney-sector-flow"
-
-BOARD_TYPES = ("industry", "concept", "regional")
+ENDPOINT = "/api/v2/market/data/etf-component-details"
 
 HEADERS = {
     "X-Client-Name": "ft-claw",
@@ -51,30 +49,16 @@ def safe_urlopen(req_or_url):
 
 
 def build_params(args):
-    params = {}
-    if args.board_code is not None:
-        params["board_code"] = args.board_code
-    if args.board_type is not None:
-        params["board_type"] = args.board_type
-    if args.board_level is not None:
-        params["board_level"] = args.board_level
+    params = {"symbol": args.symbol}
     if args.trade_date is not None:
         params["trade_date"] = args.trade_date
-    if args.start_date is not None:
-        params["start_date"] = args.start_date
-    if args.end_date is not None:
-        params["end_date"] = args.end_date
-    if args.page is not None:
-        params["page"] = args.page
-    if args.page_size is not None:
-        params["page_size"] = args.page_size
     return params
 
 
 def fetch(params):
-    query = ("?" + urllib.parse.urlencode(params)) if params else ""
+    query = urllib.parse.urlencode(params)
     req = urllib.request.Request(
-        f"{BASE_URL}{ENDPOINT}{query}",
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,19 +75,11 @@ def fetch(params):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="东方财富板块（行业/概念/地域）日资金流")
-    parser.add_argument("--board-code", dest="board_code", default=None,
-                        help="板块代码，如 BK0488")
-    parser.add_argument("--board-type", dest="board_type", default=None, choices=BOARD_TYPES,
-                        help="板块类型：industry（行业）/concept（概念）/regional（地域）")
-    parser.add_argument("--board-level", dest="board_level", type=int, default=None,
-                        help="行业层级：1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry")
-    parser.add_argument("--trade-date", dest="trade_date", default=None, help="交易日 YYYYMMDD")
-    parser.add_argument("--start-date", dest="start_date", default=None, help="区间起始日 YYYYMMDD")
-    parser.add_argument("--end-date", dest="end_date", default=None, help="区间结束日 YYYYMMDD")
-    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1")
-    parser.add_argument("--page-size", dest="page_size", type=int, default=None,
-                        help="每页条数，默认 50，最大 500")
+    parser = argparse.ArgumentParser(description="按 ETF 和交易日查询申赎清单全部成分证券及数量")
+    parser.add_argument("--symbol", required=True,
+                        help="ETF 代码，如 510300.SH、159915.SZ")
+    parser.add_argument("--trade-date", dest="trade_date", type=int, default=None,
+                        help="交易日 YYYYMMDD；不传时查询该 ETF 最新可用交易日")
     args = parser.parse_args()
 
     print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))

--- a/ftshare-market-data/sub-skills/etf-net-value/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-net-value/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: etf-net-value
+description: 查询 ETF 历史净值（etf_net_value）。用户问 ETF 净值、单位净值、累计净值、净值增长率、复权净值、每万份收益、7 日年化收益率时使用。
+---
+
+# ETF 历史净值
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | ETF 净值（etf_net_value） |
+| 外部接口 | `GET /api/v2/market/data/etf-net-value` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按 ETF 代码分页查询历史净值：发布日、净值日期、资产净值、单位净值、累计净值、净值增长率、复权净值、每万份收益、7 日年化收益率；支持单日或日期区间查询 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| etf_code | string | 是 | ETF 代码 | 510300 | 兼容参数名 `fund_code`，建议使用 `etf_code` |
+| nav_date | int | 二选一 | 净值日期 | 20260909 | YYYYMMDD；与日期区间参数互斥 |
+| start_date | int | 二选一 | 净值开始日期 | 20260901 | 须与 `end_date` 同时提供 |
+| end_date | int | 二选一 | 净值结束日期 | 20260909 | 须与 `start_date` 同时提供 |
+| page | int | 否 | 页码 | 1 | 从 1 开始，默认 1 |
+| page_size | int | 否 | 每页条数 | 50 | 默认 50，最大 200 |
+| --all | - | 否 | 自动翻页拉全量 | - | 仅本子 skill 扩展参数 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为分页对象：`items`（列表）、`total_pages`、`total_items`。
+
+items 元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| trade_code | string | ETF 交易代码 |
+| publish_date | int | 发布日期 YYYYMMDD |
+| nav_date | int | 净值日期 YYYYMMDD |
+| net_asset | string | 资产净值 |
+| unit_nav | string | 单位净值 |
+| unit_nav_growth | string | 单位净值增长率（%） |
+| accumulated_nav | string | 累计单位净值 |
+| adjustment_factor | string | 复权因子 |
+| adjusted_unit_nav | string | 复权单位净值 |
+| adjusted_unit_nav_growth | string | 复权单位净值增长率（%） |
+| daily_profit | string | 每万份基金收益 |
+| seven_day_annualized_return | string | 7 日年化收益率（%） |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-net-value --etf-code 510300 --nav-date 20260909
+python <RUN_PY> etf-net-value --etf-code 510300 --start-date 20260901 --end-date 20260909 --page 1 --page-size 5
+python <RUN_PY> etf-net-value --etf-code 510300 --start-date 20260801 --end-date 20260909 --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 必须提供 `nav_date`，或同时提供 `start_date` 和 `end_date`；二者互斥（handler 会在本地校验并拒绝）。
+- 日期格式 YYYYMMDD；区间查询包含开始和结束日期，`start_date` 不得晚于 `end_date`。
+- 数值字段以字符串形式返回，以保留小数精度。
+- `--all` 会按 `total_pages` 自动翻页，把所有 `items` 合并为一个数组返回。

--- a/ftshare-market-data/sub-skills/etf-net-value/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-net-value/scripts/handler.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""ETF 历史净值（GET /api/v2/market/data/etf-net-value）"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+
+def _require_api_key():
+    key = os.environ.get("FTSHARE_API_KEY")
+    if not key:
+        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr)
+        raise SystemExit(2)
+    return key
+
+
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+ENDPOINT = "/api/v2/market/data/etf-net-value"
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    base_parsed = urllib.parse.urlparse(BASE_URL)
+    if parsed.scheme != base_parsed.scheme or parsed.netloc != base_parsed.netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(req_or_url, urllib.request.Request):
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    if isinstance(req_or_url, urllib.request.Request):
+        for key, value in _REQUEST_HEADERS.items():
+            req_or_url.add_unredirected_header(key, value)
+    else:
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def build_params(args):
+    params = {"etf_code": args.etf_code}
+    if args.nav_date is not None:
+        params["nav_date"] = args.nav_date
+    if args.start_date is not None:
+        params["start_date"] = args.start_date
+    if args.end_date is not None:
+        params["end_date"] = args.end_date
+    params["page"] = args.page
+    params["page_size"] = args.page_size
+    return params
+
+
+def fetch_page(params):
+    query = urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        f"{BASE_URL}{ENDPOINT}?{query}",
+        headers={**HEADERS, **_REQUEST_HEADERS},
+        method="GET",
+    )
+    try:
+        with safe_urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    _require_api_key()
+    parser = argparse.ArgumentParser(description="按 ETF 代码分页查询历史净值")
+    parser.add_argument("--etf-code", dest="etf_code", required=True,
+                        help="ETF 代码，如 510300")
+    parser.add_argument("--nav-date", dest="nav_date", type=int, default=None,
+                        help="净值日期 YYYYMMDD；与日期区间参数互斥，二者必须二选一")
+    parser.add_argument("--start-date", dest="start_date", type=int, default=None,
+                        help="净值开始日期 YYYYMMDD；须与 --end-date 同时提供")
+    parser.add_argument("--end-date", dest="end_date", type=int, default=None,
+                        help="净值结束日期 YYYYMMDD；须与 --start-date 同时提供")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始，默认 1")
+    parser.add_argument("--page-size", dest="page_size", type=int, default=50,
+                        help="每页条数，默认 50，最大 200")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
+    args = parser.parse_args()
+
+    if args.nav_date is not None and (args.start_date is not None or args.end_date is not None):
+        print("--nav-date 不能与 --start-date/--end-date 同时使用", file=sys.stderr)
+        raise SystemExit(2)
+    if args.nav_date is None and (args.start_date is None or args.end_date is None):
+        print("必须提供 --nav-date，或同时提供 --start-date 和 --end-date", file=sys.stderr)
+        raise SystemExit(2)
+
+    params = build_params(args)
+    if args.fetch_all:
+        first = fetch_page(params)
+        data = first.get("data") or {}
+        items = list(data.get("items", []))
+        total_pages = data.get("total_pages") or 1
+        for page in range(2, total_pages + 1):
+            page_data = fetch_page({**params, "page": page})
+            items.extend((page_data.get("data") or {}).get("items", []))
+        result = {
+            "items": items,
+            "total_pages": total_pages,
+            "total_items": data.get("total_items", len(items)),
+        }
+    else:
+        result = fetch_page(params)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/etf-net-value/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/etf-net-value/scripts/test_handler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Tests for etf-net-value handler"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            handler.main()
+
+
+class TestDateModes(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_requires_nav_date_or_range(self):
+        with self.assertRaises(SystemExit):
+            _run(["--etf-code", "510300", "--page", "1", "--page-size", "5"])
+
+    def test_rejects_nav_date_with_range(self):
+        with self.assertRaises(SystemExit):
+            _run(["--etf-code", "510300", "--nav-date", "20260909",
+                  "--start-date", "20260901", "--end-date", "20260909"])
+
+    def test_rejects_partial_range(self):
+        with self.assertRaises(SystemExit):
+            _run(["--etf-code", "510300", "--start-date", "20260901"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_accepts_nav_date(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--etf-code", "510300", "--nav-date", "20260909"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v2/market/data/etf-net-value", req.full_url)
+        self.assertIn("etf_code=510300", req.full_url)
+        self.assertIn("nav_date=20260909", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_accepts_range(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--etf-code", "510300", "--start-date", "20260901", "--end-date", "20260909"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("start_date=20260901", req.full_url)
+        self.assertIn("end_date=20260909", req.full_url)
+        self.assertNotIn("nav_date", req.full_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/etf-pcf-infos/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-pcf-infos/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: etf-pcf-infos
+description: 查询 ETF 申赎清单（PCF 汇总信息，etf_pcf_infos）。用户问 ETF 申赎清单、PCF 汇总、申购赎回单位、现金替代金额、预估现金差额、成分证券数量、ETF PCF 信息时使用。
+---
+
+# ETF 申赎清单（PCF 汇总信息）
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | ETF 申赎清单（etf_pcf_infos） |
+| 外部接口 | `GET /api/v2/market/data/etf-pcf/etf-pcf-infos` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 查询 ETF 的 PCF（申购赎回清单）汇总信息：申购赎回单位、现金替代金额、预估现金差额、现金替代比例上限、成分证券数量 |
+
+支持三种查询模式：
+
+1. **单标的单日**：同时传 `symbol` + `trade_date`，`data` 直接返回一条 PCF 信息对象。
+2. **全市场单日**：只传 `trade_date`，`data` 返回分页对象。
+3. **单标的区间**：同时传 `symbol` + `start_date` + `end_date`，`data` 返回分页对象（区间最长 30 个日历日）。
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 视模式 | ETF 代码 | 510300.SH | 支持短/长市场后缀（`510300.XSHG`） |
+| trade_date | int | 视模式 | 交易日 | 20260909 | YYYYMMDD；与日期区间参数互斥 |
+| start_date | int | 视模式 | 区间开始日期 | 20260901 | 须与 `end_date`、`symbol` 同时提供 |
+| end_date | int | 视模式 | 区间结束日期 | 20260909 | 须与 `start_date`、`symbol` 同时提供 |
+| page | int | 否 | 页码 | 1 | 从 1 开始，默认 1；分页查询有效 |
+| page_size | int | 否 | 每页条数 | 50 | 默认 50，最大 500；分页查询有效 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 在单标的单日模式下为对象，分页模式下为分页对象（`pageNum`/`pageSize`/`total`/`pages`/`records`）。
+
+PCF 信息字段：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| symbol | string | ETF 代码（短市场后缀） |
+| trade_date | int | 交易日 YYYYMMDD |
+| creation_redemption_unit | int / null | 申购赎回单位（份） |
+| cash_substitution | string / null | 现金替代金额 |
+| estimated_cash | string / null | 预估现金差额 |
+| iopv | string / null | 基金份额参考净值；当前为 `null`（保留字段） |
+| min_creation_unit | int / null | 最小申购单位（份） |
+| max_cash_ratio | string / null | 现金替代比例上限 |
+| component_count | int / null | 成分证券数量 |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-pcf-infos --symbol 510300.SH --trade-date 20260909
+python <RUN_PY> etf-pcf-infos --trade-date 20260909 --page 1 --page-size 5
+python <RUN_PY> etf-pcf-infos --symbol 510300.SH --start-date 20260901 --end-date 20260909 --page 1 --page-size 5
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- `trade_date` 不能与 `start_date`、`end_date` 同时使用（handler 会在本地校验并拒绝）。
+- `start_date` 必须早于 `end_date`，区间最长 30 个日历日。
+- 单标的单日查询未命中数据时，仍返回对应标的和日期，其余业务字段为 `null`。
+- `iopv` 为保留字段，当前返回 `null`。
+- 金额和比例字段以字符串形式返回，以保留小数精度。
+- 需要指定日期的 PCF 文件清单（XML 文件名）请使用 `etf-pcfs` 子 skill；本接口返回的是汇总指标。

--- a/ftshare-market-data/sub-skills/etf-pcf-infos/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-pcf-infos/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""东方财富板块资金流（GET /api/v1/market/data/eastmoney-sector-flow）"""
+"""ETF 申赎清单 PCF 汇总信息（GET /api/v2/market/data/etf-pcf/etf-pcf-infos）"""
 import argparse
 import json
 import sys
@@ -20,9 +20,7 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v1/market/data/eastmoney-sector-flow"
-
-BOARD_TYPES = ("industry", "concept", "regional")
+ENDPOINT = "/api/v2/market/data/etf-pcf/etf-pcf-infos"
 
 HEADERS = {
     "X-Client-Name": "ft-claw",
@@ -50,14 +48,10 @@ def safe_urlopen(req_or_url):
     return SAFE_URLOPENER.open(req_or_url)
 
 
-def build_params(args):
+def build_query(args):
     params = {}
-    if args.board_code is not None:
-        params["board_code"] = args.board_code
-    if args.board_type is not None:
-        params["board_type"] = args.board_type
-    if args.board_level is not None:
-        params["board_level"] = args.board_level
+    if args.symbol is not None:
+        params["symbol"] = args.symbol
     if args.trade_date is not None:
         params["trade_date"] = args.trade_date
     if args.start_date is not None:
@@ -91,22 +85,26 @@ def fetch(params):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="东方财富板块（行业/概念/地域）日资金流")
-    parser.add_argument("--board-code", dest="board_code", default=None,
-                        help="板块代码，如 BK0488")
-    parser.add_argument("--board-type", dest="board_type", default=None, choices=BOARD_TYPES,
-                        help="板块类型：industry（行业）/concept（概念）/regional（地域）")
-    parser.add_argument("--board-level", dest="board_level", type=int, default=None,
-                        help="行业层级：1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry")
-    parser.add_argument("--trade-date", dest="trade_date", default=None, help="交易日 YYYYMMDD")
-    parser.add_argument("--start-date", dest="start_date", default=None, help="区间起始日 YYYYMMDD")
-    parser.add_argument("--end-date", dest="end_date", default=None, help="区间结束日 YYYYMMDD")
-    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1")
+    parser = argparse.ArgumentParser(
+        description="ETF 申赎清单（PCF 汇总信息）：单标的单日 / 全市场单日分页 / 单标的日期区间"
+    )
+    parser.add_argument("--symbol", default=None, help="ETF 代码，如 510300.SH 或 510300.XSHG")
+    parser.add_argument("--trade-date", dest="trade_date", type=int, default=None,
+                        help="交易日 YYYYMMDD；单日查询时必填，不能与日期区间同用")
+    parser.add_argument("--start-date", dest="start_date", type=int, default=None,
+                        help="区间开始日期 YYYYMMDD；须与 --end-date、--symbol 同时提供")
+    parser.add_argument("--end-date", dest="end_date", type=int, default=None,
+                        help="区间结束日期 YYYYMMDD；须与 --start-date、--symbol 同时提供")
+    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1；分页查询有效")
     parser.add_argument("--page-size", dest="page_size", type=int, default=None,
-                        help="每页条数，默认 50，最大 500")
+                        help="每页条数，默认 50，最大 500；分页查询有效")
     args = parser.parse_args()
 
-    print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
+    if args.trade_date is not None and (args.start_date is not None or args.end_date is not None):
+        print("--trade-date 不能与 --start-date/--end-date 同时使用", file=sys.stderr)
+        raise SystemExit(2)
+
+    print(json.dumps(fetch(build_query(args)), ensure_ascii=False, indent=2))
 
 
 if __name__ == "__main__":

--- a/ftshare-market-data/sub-skills/etf-pcf-infos/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/etf-pcf-infos/scripts/test_handler.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for etf-pcf-infos handler"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            handler.main()
+
+
+class TestModes(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_rejects_trade_date_with_range(self):
+        with self.assertRaises(SystemExit):
+            _run(["--symbol", "510300.SH", "--trade-date", "20260909",
+                  "--start-date", "20260901", "--end-date", "20260909"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_single_symbol_single_day(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--symbol", "510300.SH", "--trade-date", "20260909"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v2/market/data/etf-pcf/etf-pcf-infos", req.full_url)
+        self.assertIn("symbol=510300.SH", req.full_url)
+        self.assertIn("trade_date=20260909", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_omits_unset_optionals(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--trade-date", "20260909"])
+        req = mock_open.call_args[0][0]
+        self.assertNotIn("symbol", req.full_url)
+        self.assertNotIn("page", req.full_url)
+        self.assertNotIn("page_size", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_range_mode_keeps_paging(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--symbol", "510300.SH", "--start-date", "20260901",
+              "--end-date", "20260909", "--page", "2", "--page-size", "5"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("start_date=20260901", req.full_url)
+        self.assertIn("page=2", req.full_url)
+        self.assertIn("page_size=5", req.full_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/etf-share/SKILL.md
+++ b/ftshare-market-data/sub-skills/etf-share/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: etf-share
+description: 查询 ETF 份额变动（etf_share）。用户问 ETF 份额、期末份额、申购赎回份额、份额净变动、份额变动率、ETF 份额历史时使用。
+---
+
+# ETF 份额变动
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | ETF 份额（etf_share） |
+| 外部接口 | `GET /api/v2/market/data/etf-share` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按 ETF 代码分页查询份额变动：统计周期、统计日期、期末/期初份额、申购/赎回份额、份额净变动和份额变动率，支持按统计周期和日期范围筛选 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| etf_code | string | 是 | ETF 代码 | 510300 | 兼容参数名 `fund_code`，建议使用 `etf_code` |
+| stati_perd | string | 否 | 统计周期 | 全部 | `日`/`季度`/`年度`/`截止时点`/`半年`/`全部`；不传默认 `全部` |
+| start_date | int | 否 | 开始日期 | 20250101 | YYYYMMDD，按 `trade_date` 过滤 |
+| end_date | int | 否 | 结束日期 | 20260909 | YYYYMMDD，按 `trade_date` 过滤；不早于 `start_date` |
+| page | int | 否 | 页码 | 1 | 从 1 开始，默认 1 |
+| page_size | int | 否 | 每页条数 | 50 | 默认 50，最大 200 |
+| --all | - | 否 | 自动翻页拉全量 | - | 仅本子 skill 扩展参数 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为分页对象：`items`（列表）、`total_pages`、`total_items`。
+
+items 元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| trade_code | string | ETF 交易代码 |
+| statistics_period | string | 统计周期 |
+| trade_date | int | 统计日期 YYYYMMDD |
+| fund_share | string | 期末份额（份） |
+| begin_shares | string / null | 期初份额（份） |
+| purchase_shares | string / null | 申购份额（份） |
+| redemption_shares | string / null | 赎回份额（份） |
+| shares_change | string / null | 份额净变动（份） |
+| shares_change_ratio | string / null | 份额变动率（%） |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> etf-share --etf-code 510300 --page 1 --page-size 5
+python <RUN_PY> etf-share --etf-code 510300 --stati-perd 日 --start-date 20250101 --end-date 20260909
+python <RUN_PY> etf-share --etf-code 510300 --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 份额字段单位为份；数值字段以字符串形式返回，以保留小数精度。
+- `start_date` / `end_date` 可单独提供；同时提供时 `start_date` 不得晚于 `end_date`。
+- `--all` 会按 `total_pages` 自动翻页，把所有 `items` 合并为一个数组返回。

--- a/ftshare-market-data/sub-skills/etf-share/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/etf-share/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""东方财富板块资金流（GET /api/v1/market/data/eastmoney-sector-flow）"""
+"""ETF 份额变动（GET /api/v2/market/data/etf-share）"""
 import argparse
 import json
 import sys
@@ -20,14 +20,14 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v1/market/data/eastmoney-sector-flow"
-
-BOARD_TYPES = ("industry", "concept", "regional")
+ENDPOINT = "/api/v2/market/data/etf-share"
 
 HEADERS = {
     "X-Client-Name": "ft-claw",
     "Content-Type": "application/json",
 }
+
+STATI_PERD = ("日", "季度", "年度", "截止时点", "半年", "全部")
 
 
 def safe_urlopen(req_or_url):
@@ -51,30 +51,22 @@ def safe_urlopen(req_or_url):
 
 
 def build_params(args):
-    params = {}
-    if args.board_code is not None:
-        params["board_code"] = args.board_code
-    if args.board_type is not None:
-        params["board_type"] = args.board_type
-    if args.board_level is not None:
-        params["board_level"] = args.board_level
-    if args.trade_date is not None:
-        params["trade_date"] = args.trade_date
+    params = {"etf_code": args.etf_code}
+    if args.stati_perd is not None:
+        params["stati_perd"] = args.stati_perd
     if args.start_date is not None:
         params["start_date"] = args.start_date
     if args.end_date is not None:
         params["end_date"] = args.end_date
-    if args.page is not None:
-        params["page"] = args.page
-    if args.page_size is not None:
-        params["page_size"] = args.page_size
+    params["page"] = args.page
+    params["page_size"] = args.page_size
     return params
 
 
-def fetch(params):
-    query = ("?" + urllib.parse.urlencode(params)) if params else ""
+def fetch_page(params):
+    query = urllib.parse.urlencode(params)
     req = urllib.request.Request(
-        f"{BASE_URL}{ENDPOINT}{query}",
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,22 +83,39 @@ def fetch(params):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="东方财富板块（行业/概念/地域）日资金流")
-    parser.add_argument("--board-code", dest="board_code", default=None,
-                        help="板块代码，如 BK0488")
-    parser.add_argument("--board-type", dest="board_type", default=None, choices=BOARD_TYPES,
-                        help="板块类型：industry（行业）/concept（概念）/regional（地域）")
-    parser.add_argument("--board-level", dest="board_level", type=int, default=None,
-                        help="行业层级：1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry")
-    parser.add_argument("--trade-date", dest="trade_date", default=None, help="交易日 YYYYMMDD")
-    parser.add_argument("--start-date", dest="start_date", default=None, help="区间起始日 YYYYMMDD")
-    parser.add_argument("--end-date", dest="end_date", default=None, help="区间结束日 YYYYMMDD")
-    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1")
-    parser.add_argument("--page-size", dest="page_size", type=int, default=None,
-                        help="每页条数，默认 50，最大 500")
+    parser = argparse.ArgumentParser(description="按 ETF 代码分页查询份额变动")
+    parser.add_argument("--etf-code", dest="etf_code", required=True,
+                        help="ETF 代码，如 510300")
+    parser.add_argument("--stati-perd", dest="stati_perd", default=None, choices=STATI_PERD,
+                        help="统计周期：日/季度/年度/截止时点/半年/全部；不传默认全部")
+    parser.add_argument("--start-date", dest="start_date", type=int, default=None,
+                        help="开始日期 YYYYMMDD，按 trade_date 过滤")
+    parser.add_argument("--end-date", dest="end_date", type=int, default=None,
+                        help="结束日期 YYYYMMDD，按 trade_date 过滤")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始，默认 1")
+    parser.add_argument("--page-size", dest="page_size", type=int, default=50,
+                        help="每页条数，默认 50，最大 200")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
     args = parser.parse_args()
 
-    print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
+    params = build_params(args)
+    if args.fetch_all:
+        first = fetch_page(params)
+        data = first.get("data") or {}
+        items = list(data.get("items", []))
+        total_pages = data.get("total_pages") or 1
+        for page in range(2, total_pages + 1):
+            page_data = fetch_page({**params, "page": page})
+            items.extend((page_data.get("data") or {}).get("items", []))
+        result = {
+            "items": items,
+            "total_pages": total_pages,
+            "total_items": data.get("total_items", len(items)),
+        }
+    else:
+        result = fetch_page(params)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
 
 
 if __name__ == "__main__":

--- a/ftshare-market-data/sub-skills/futures-contract-kline/SKILL.md
+++ b/ftshare-market-data/sub-skills/futures-contract-kline/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: futures-contract-kline
+description: 查询期货行情（期货合约日/周/月/季/年 K 线，futures_contract_kline）。用户问期货合约 K 线、期货日K/周K/月K、合约开高低收、期货成交量持仓量、vwap、主力合约复权因子时使用。
+---
+
+# 期货行情（期货合约 K 线）
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 期货行情（futures_contract_kline） |
+| 外部接口 | `GET /api/v1/market/data/futures/kline` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 查询期货合约日、周、月、季、年 K 线，含开高低收、成交量、成交额、vwap、持仓量、主力合约与前/后复权因子 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 是 | 期货合约代码 | A2605.DCE | 支持交易所短后缀 |
+| interval | string | 否 | K 线周期 | daily | `daily`/`1d`、`weekly`/`1w`/`week`、`monthly`/`1mo`/`month`、`quarterly`/`1q`/`quarter`、`yearly`/`1y`/`year`；默认 `daily` |
+| start | int | 否 | 起始时间戳（毫秒） | 1756431000000 | 闭区间；可省略时间范围 |
+| end | int | 否 | 结束时间戳（毫秒） | 1756791000000 | 闭区间；不能单独传入 |
+| limit | int | 否 | 返回条数 | 5 | 默认 500，最小值 1，传 0 时按 1 处理 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为对象：`items`（K 线记录列表）和 `total`（符合条件记录总数）。
+
+items 元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| symbol | string | 规范化后的合约代码 |
+| datetime | int64 | K 线时间戳（毫秒） |
+| trade_date | int | 交易日 YYYYMMDD |
+| open / high / low / close | number | 开盘价 / 最高价 / 最低价 / 收盘价 |
+| volume | int64 | 成交量 |
+| amount | number | 成交额 |
+| vwap | number | 成交均价 |
+| open_interest | number | 持仓量 |
+| dominant_contract | string / null | 主力合约；合约 K 线不返回该字段值 |
+| forward_factor | number / null | 前复权因子；合约 K 线不返回该字段值 |
+| backward_factor | number / null | 后复权因子；合约 K 线不返回该字段值 |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> futures-contract-kline --symbol A2605.DCE --interval daily --limit 5
+python <RUN_PY> futures-contract-kline --symbol A2605.DCE --interval weekly --limit 5
+python <RUN_PY> futures-contract-kline --symbol A2605.DCE --start 1756431000000 --end 1756791000000
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 周、月、季、年 K 线基于日 K 线按北京时间聚合。
+- `end` 不能单独传入，必须与 `start` 同时使用（handler 会本地校验并拒绝）；仅传 `start` 时查询 `start` 之后的数据。
+- 同时传入 `start` 和 `end` 时，跨度不得超过 12 个日历月。
+- 本接口查询的是具体合约 K 线；`dominant_contract` 和复权因子字段对合约 K 线不返回值。

--- a/ftshare-market-data/sub-skills/futures-contract-kline/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/futures-contract-kline/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""东方财富板块资金流（GET /api/v1/market/data/eastmoney-sector-flow）"""
+"""期货行情：期货合约日/周/月/季/年 K 线（GET /api/v1/market/data/futures/kline）"""
 import argparse
 import json
 import sys
@@ -20,9 +20,15 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v1/market/data/eastmoney-sector-flow"
+ENDPOINT = "/api/v1/market/data/futures/kline"
 
-BOARD_TYPES = ("industry", "concept", "regional")
+INTERVALS = (
+    "daily", "1d",
+    "weekly", "1w", "week",
+    "monthly", "1mo", "month",
+    "quarterly", "1q", "quarter",
+    "yearly", "1y", "year",
+)
 
 HEADERS = {
     "X-Client-Name": "ft-claw",
@@ -51,30 +57,23 @@ def safe_urlopen(req_or_url):
 
 
 def build_params(args):
-    params = {}
-    if args.board_code is not None:
-        params["board_code"] = args.board_code
-    if args.board_type is not None:
-        params["board_type"] = args.board_type
-    if args.board_level is not None:
-        params["board_level"] = args.board_level
-    if args.trade_date is not None:
-        params["trade_date"] = args.trade_date
-    if args.start_date is not None:
-        params["start_date"] = args.start_date
-    if args.end_date is not None:
-        params["end_date"] = args.end_date
-    if args.page is not None:
-        params["page"] = args.page
-    if args.page_size is not None:
-        params["page_size"] = args.page_size
+    params = {
+        "symbol": args.symbol,
+        "interval": args.interval,
+    }
+    if args.start is not None:
+        params["start"] = args.start
+    if args.end is not None:
+        params["end"] = args.end
+    if args.limit is not None:
+        params["limit"] = args.limit
     return params
 
 
 def fetch(params):
-    query = ("?" + urllib.parse.urlencode(params)) if params else ""
+    query = urllib.parse.urlencode(params)
     req = urllib.request.Request(
-        f"{BASE_URL}{ENDPOINT}{query}",
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,20 +90,22 @@ def fetch(params):
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="东方财富板块（行业/概念/地域）日资金流")
-    parser.add_argument("--board-code", dest="board_code", default=None,
-                        help="板块代码，如 BK0488")
-    parser.add_argument("--board-type", dest="board_type", default=None, choices=BOARD_TYPES,
-                        help="板块类型：industry（行业）/concept（概念）/regional（地域）")
-    parser.add_argument("--board-level", dest="board_level", type=int, default=None,
-                        help="行业层级：1=一级、2=二级、3=三级；不传返回全部层级，仅匹配 industry")
-    parser.add_argument("--trade-date", dest="trade_date", default=None, help="交易日 YYYYMMDD")
-    parser.add_argument("--start-date", dest="start_date", default=None, help="区间起始日 YYYYMMDD")
-    parser.add_argument("--end-date", dest="end_date", default=None, help="区间结束日 YYYYMMDD")
-    parser.add_argument("--page", type=int, default=None, help="页码，从 1 开始，默认 1")
-    parser.add_argument("--page-size", dest="page_size", type=int, default=None,
-                        help="每页条数，默认 50，最大 500")
+    parser = argparse.ArgumentParser(description="查询期货合约日/周/月/季/年 K 线")
+    parser.add_argument("--symbol", required=True,
+                        help="期货合约代码，如 A2605.DCE；支持交易所短后缀")
+    parser.add_argument("--interval", default="daily", choices=INTERVALS,
+                        help="K 线周期，默认 daily；周/月/季/年 K 基于日 K 按北京时间聚合")
+    parser.add_argument("--start", type=int, default=None,
+                        help="起始时间戳（毫秒，闭区间）；可省略时间范围")
+    parser.add_argument("--end", type=int, default=None,
+                        help="结束时间戳（毫秒，闭区间）；不能单独传入")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="返回条数，默认 500；最小值 1，传 0 时按 1 处理")
     args = parser.parse_args()
+
+    if args.end is not None and args.start is None:
+        print("--end 不能单独传入，必须与 --start 同时使用", file=sys.stderr)
+        raise SystemExit(2)
 
     print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
 

--- a/ftshare-market-data/sub-skills/futures-contract-kline/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/futures-contract-kline/scripts/test_handler.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Tests for futures-contract-kline handler"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            handler.main()
+
+
+class TestParams(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_rejects_end_without_start(self):
+        with self.assertRaises(SystemExit):
+            _run(["--symbol", "A2605.DCE", "--end", "1756791000000"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_defaults(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--symbol", "A2605.DCE"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v1/market/data/futures/kline", req.full_url)
+        self.assertIn("symbol=A2605.DCE", req.full_url)
+        self.assertIn("interval=daily", req.full_url)
+        self.assertNotIn("limit", req.full_url)
+        self.assertNotIn("start", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_weekly_interval(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--symbol", "A2605.DCE", "--interval", "weekly", "--limit", "5",
+              "--start", "1756431000000", "--end", "1756791000000"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("interval=weekly", req.full_url)
+        self.assertIn("limit=5", req.full_url)
+        self.assertIn("start=1756431000000", req.full_url)
+        self.assertIn("end=1756791000000", req.full_url)
+
+    def test_rejects_unknown_interval(self):
+        with self.assertRaises(SystemExit):
+            _run(["--symbol", "A2605.DCE", "--interval", "minute"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/futures-settle/SKILL.md
+++ b/ftshare-market-data/sub-skills/futures-settle/SKILL.md
@@ -7,10 +7,10 @@ description: 期货每日结算参数。调用 /api/v1/market/data/futures/fut-s
 
 外部接口：`GET /api/v1/market/data/futures/fut-settle`。
 
-支持源接口文档列出的查询参数，handler 将参数作为 query 发送，并以 JSON 输出响应。所有请求必须设置环境变量 `FTSHARE_API_KEY`；缺失凭据时不会发起请求。
+支持源接口文档列出的查询参数，handler 将参数作为 query 发送，并以 JSON 输出响应。`--exchange` 必填（`SHFE`/`INE`/`CZCE`/`CFFEX`/`DCE`/`GFEX`）；`--trade-date` 与 `--start-date`/`--end-date` 二选一，区间跨度不超过 31 天。所有请求必须设置环境变量 `FTSHARE_API_KEY`；缺失凭据时不会发起请求。
 
 ## 调用示例
 
 ```bash
-python <RUN_PY> futures-settle --ts-code A2609.DCE --trade-date 20260721 --page 1 --page-size 5
+python <RUN_PY> futures-settle --exchange DCE --ts-code A2609.DCE --trade-date 20260721 --page 1 --page-size 5
 ```

--- a/ftshare-market-data/sub-skills/index-candlesticks-batch/SKILL.md
+++ b/ftshare-market-data/sub-skills/index-candlesticks-batch/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: index-candlesticks-batch
+description: 批量查询多个指数的历史 K 线（index_candlesticks_batch）。用户问多个指数日/周/月/年 K 线、批量指数开高低收、指数批量行情、多指数对比 K 线时使用。
+---
+
+# 批量指数K线
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 批量指数K线（index_candlesticks_batch） |
+| 外部接口 | `GET /api/v2/market/data/index-candlesticks/batch` |
+| 请求方式 | GET（query 参数，`symbols` 可重复传入） |
+| 适用场景 | 一次批量获取多个指数的历史 K 线（开高低收、成交量、成交额、换手率），支持日/周/月/年周期与前复权/后复权 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbols | string[] | 是 | 指数代码列表，逗号分隔传给 CLI | 000300.SH,399001.SZ | 沪市支持 `.XSHG`/`.SH`，深市支持 `.XSHE`/`.SZ`；接口侧以重复 query 参数发送 |
+| interval_unit | string | 是 | 周期单位 | Day | Day/Week/Month/Year，大小写不敏感；**不支持 Minute** |
+| adjust_kind | string | 否 | 复权类型 | Forward | None（默认）/Forward（前复权）/Backward（后复权） |
+| since_ts_millis | int | 是 | 开始时间戳（毫秒） | 1756431000000 | 与 until 的跨度不得超过 12 个日历月；不得晚于 until |
+| until_ts_millis | int | 是 | 结束时间戳（毫秒） | 1756791000000 | - |
+| limit | int | 否 | 每个标的返回条数上限 | 2 | 不传时返回请求时间范围内的全部数据 |
+
+## 3. 响应说明
+
+外层固定为 `code`（成功 200）/ `message`（成功 `success`）/ `data`（失败时为 `null`）。`data` 为非分页嵌套数组，外层每项为 `[symbol, K线数组]`，每根 K 线字段：
+
+| 字段名 | 类型 | 说明 | 单位 |
+|--------|------|------|------|
+| symbol | string | 指数代码，响应统一使用 `.SH`、`.SZ` 短后缀 | - |
+| open / high / low / close | number | 开/高/低/收盘点位 | 指数点 |
+| ts_millis | string | 收盘时间戳 | 毫秒 |
+| ts_millis_open | string | 开盘时间戳 | 毫秒 |
+| turnover | number | 成交额（指数成分股合计） | 元 |
+| volume | integer | 成交量（指数成分股合计） | - |
+| turnover_rate | number | 换手率；指数标的当前为 `null` | % |
+
+注：`open/high/low/close`、`turnover` 在 JSON 中实际以字符串返回（避免精度丢失）；`ts_millis` 为数字。
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> index-candlesticks-batch --symbols 000300.SH,399001.SZ --interval-unit Day --since-ts-millis 1756431000000 --until-ts-millis 1756791000000 --limit 2
+python <RUN_PY> index-candlesticks-batch --symbols 000300.XSHG,399001.XSHE --interval-unit Week --adjust-kind Forward --since-ts-millis 1754092800000 --until-ts-millis 1756791000000
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- `symbols`、`interval_unit`、`since_ts_millis`、`until_ts_millis` 必填；所有 `symbols` 使用相同周期。
+- 接口仅支持 GET；`symbols` 在查询参数中以重复参数形式发送（`symbols=000300.SH&symbols=399001.SZ`）。
+- 时间跨度最多 12 个日历月；需要更长历史时按窗口分段多次调用。
+- 不支持分钟 K 线；分钟数据请使用 `index-minutes-batch` 子 skill。
+- `symbols` 中每项必须是指数标的：若混入非指数（如 ETF、股票），整个批量请求失败，不静默过滤（当前返回系统错误）。
+- 输入 `.XSHG`/`.XSHE` 长后缀时，响应中的 symbol 会规范化为 `.SH`、`.SZ` 短后缀。
+- 默认不复权（None）；仅使用历史日 K 数据计算，不含实时行情，实际起始日期以行情数据源覆盖为准。

--- a/ftshare-market-data/sub-skills/index-candlesticks-batch/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/index-candlesticks-batch/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""批量查询多只标的 K 线（GET /api/v2/market/data/stock-candlesticks/batch）"""
+"""批量查询多个指数 K 线（GET /api/v2/market/data/index-candlesticks/batch）"""
 import argparse
 import json
 import sys
@@ -20,10 +20,15 @@ SAFE_URLOPENER = urllib.request.build_opener()
 
 BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
 _REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
-ENDPOINT = "/api/v2/market/data/stock-candlesticks/batch"
+ENDPOINT = "/api/v2/market/data/index-candlesticks/batch"
 
 INTERVAL_UNITS = ("Day", "Week", "Month", "Year")
 ADJUST_KINDS = ("None", "Forward", "Backward")
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
 
 
 def safe_urlopen(req_or_url):
@@ -46,12 +51,6 @@ def safe_urlopen(req_or_url):
     return SAFE_URLOPENER.open(req_or_url)
 
 
-HEADERS = {
-    "X-Client-Name": "ft-claw",
-    "Content-Type": "application/json",
-}
-
-
 def parse_symbols(raw):
     syms = [s.strip() for s in raw.split(",") if s.strip()]
     if not syms:
@@ -60,8 +59,7 @@ def parse_symbols(raw):
     return syms
 
 
-def build_body(symbols, interval_unit, adjust_kind,
-               since_ts_millis, until_ts_millis, limit):
+def build_query(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit):
     body = {
         "symbols": symbols,
         "interval_unit": interval_unit,
@@ -76,14 +74,11 @@ def build_body(symbols, interval_unit, adjust_kind,
     return body
 
 
-def fetch(symbols, interval_unit, adjust_kind,
-          since_ts_millis, until_ts_millis, limit):
-    body = build_body(symbols, interval_unit, adjust_kind,
-                      since_ts_millis, until_ts_millis, limit)
+def fetch(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit):
+    body = build_query(symbols, interval_unit, adjust_kind, since_ts_millis, until_ts_millis, limit)
     query = urllib.parse.urlencode(body, doseq=True)
-    url = f"{BASE_URL}{ENDPOINT}?{query}"
     req = urllib.request.Request(
-        url,
+        f"{BASE_URL}{ENDPOINT}?{query}",
         headers={**HEADERS, **_REQUEST_HEADERS},
         method="GET",
     )
@@ -91,8 +86,7 @@ def fetch(symbols, interval_unit, adjust_kind,
         with safe_urlopen(req) as resp:
             return json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
-        msg = e.read().decode()
-        print(f"HTTP {e.code}: {msg}", file=sys.stderr)
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
         sys.exit(1)
     except urllib.error.URLError as e:
         print(f"Request failed: {e}", file=sys.stderr)
@@ -101,9 +95,9 @@ def fetch(symbols, interval_unit, adjust_kind,
 
 def main():
     _require_api_key()
-    parser = argparse.ArgumentParser(description="批量查询多只标的 K 线（GET 查询参数）")
+    parser = argparse.ArgumentParser(description="批量获取多个指数的历史 K 线（不支持分钟周期）")
     parser.add_argument("--symbols", required=True,
-                        help="标的代码列表，逗号分隔，如 600519.SH,510300.SH,113027.SH,000300.SH；支持长短后缀混用")
+                        help="指数代码列表，逗号分隔，如 000300.XSHG,399001.XSHE；也接受 .SH/.SZ 短后缀")
     parser.add_argument("--interval-unit", dest="interval_unit", required=True, type=str.capitalize,
                         choices=INTERVAL_UNITS, help="K 线周期：Day/Week/Month/Year（大小写不敏感，不支持 Minute）")
     parser.add_argument("--adjust-kind", dest="adjust_kind", default="None",
@@ -121,8 +115,8 @@ def main():
         raise SystemExit(2)
 
     symbols = parse_symbols(args.symbols)
-    data = fetch(symbols, args.interval_unit,
-                 args.adjust_kind, args.since_ts_millis, args.until_ts_millis, args.limit)
+    data = fetch(symbols, args.interval_unit, args.adjust_kind,
+                 args.since_ts_millis, args.until_ts_millis, args.limit)
     print(json.dumps(data, ensure_ascii=False, indent=2))
 
 

--- a/ftshare-market-data/sub-skills/index-candlesticks-batch/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/index-candlesticks-batch/scripts/test_handler.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Tests for stock-candlesticks-batch handler"""
+"""Tests for index-candlesticks-batch handler"""
 import json
 import os
 import sys
 import unittest
-import urllib.error
-from io import BytesIO, StringIO
+from io import StringIO
 from unittest.mock import patch
 import importlib.util
 
@@ -17,13 +16,13 @@ SINCE = "1756431000000"
 UNTIL = "1756791000000"
 
 
-class TestBuildBody(unittest.TestCase):
+class TestBuildQuery(unittest.TestCase):
     def setUp(self):
         spec.loader.exec_module(handler)
 
     def test_required_only(self):
-        body = handler.build_body(["600519.SH"], "Day", "None", 1756431000000, 1756791000000, None)
-        self.assertEqual(body["symbols"], ["600519.SH"])
+        body = handler.build_query(["000300.SH"], "Day", "None", 1756431000000, 1756791000000, None)
+        self.assertEqual(body["symbols"], ["000300.SH"])
         self.assertEqual(body["interval_unit"], "Day")
         self.assertEqual(body["since_ts_millis"], 1756431000000)
         self.assertNotIn("adjust_kind", body)
@@ -32,36 +31,11 @@ class TestBuildBody(unittest.TestCase):
 
     def test_minute_not_allowed(self):
         with self.assertRaises(SystemExit):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "000300.SH",
                                             "--interval-unit", "Minute",
                                             "--since-ts-millis", SINCE,
                                             "--until-ts-millis", UNTIL]):
                 handler.main()
-
-
-class TestFetch(unittest.TestCase):
-    def setUp(self):
-        spec.loader.exec_module(handler)
-
-    @patch.object(handler, "safe_urlopen")
-    def test_get_to_stock_batch_endpoint(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b"[]"
-        handler.fetch(["600519.SH", "000001.SZ"], "Day", "None",
-                      1756431000000, 1756791000000, 2)
-        req = mock_open.call_args[0][0]
-        self.assertEqual(req.get_method(), "GET")
-        self.assertIn("/api/v2/market/data/stock-candlesticks/batch", req.full_url)
-        self.assertIn("since_ts_millis=1756431000000", req.full_url)
-        self.assertIsNone(req.data)
-        self.assertEqual(req.headers.get("X-client-name"), "ft-claw")
-
-    @patch.object(handler, "safe_urlopen")
-    def test_http_error_exits(self, mock_open):
-        mock_open.side_effect = urllib.error.HTTPError(
-            "https://fake", 500, "Internal Error", {}, BytesIO(b"server error")
-        )
-        with self.assertRaises(SystemExit):
-            handler.fetch(["600519.SH"], "Day", "None", 1756431000000, 1756791000000, None)
 
 
 class TestMain(unittest.TestCase):
@@ -69,21 +43,26 @@ class TestMain(unittest.TestCase):
         spec.loader.exec_module(handler)
 
     @patch.object(handler, "safe_urlopen")
-    def test_main_emits_json(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b"[]"
+    def test_main_targets_index_route(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = (
+            b'{"code":200,"message":"success","data":[["000300.SH",[]]]}'
+        )
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", [
-                "handler.py", "--symbols", "600519.SH,000001.SZ",
-                "--interval-unit", "Day",
-                "--since-ts-millis", SINCE, "--until-ts-millis", UNTIL
-            ]):
-                with patch("sys.stdout", new_callable=StringIO) as fake_out:
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "000300.SH,399001.SZ",
+                                            "--interval-unit", "Day",
+                                            "--since-ts-millis", SINCE,
+                                            "--until-ts-millis", UNTIL]):
+                with patch("sys.stdout", new_callable=StringIO) as out:
                     handler.main()
-                    self.assertEqual(json.loads(fake_out.getvalue()), [])
+                    data = json.loads(out.getvalue())
+                    self.assertEqual(data["data"][0][0], "000300.SH")
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v2/market/data/index-candlesticks/batch", req.full_url)
+        self.assertIn("since_ts_millis=1756431000000", req.full_url)
 
     def test_main_requires_since(self):
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "000300.SH",
                                             "--interval-unit", "Day",
                                             "--until-ts-millis", UNTIL]):
                 with self.assertRaises(SystemExit):
@@ -91,7 +70,7 @@ class TestMain(unittest.TestCase):
 
     def test_main_rejects_since_after_until(self):
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "000300.SH",
                                             "--interval-unit", "Day",
                                             "--since-ts-millis", UNTIL,
                                             "--until-ts-millis", SINCE]):
@@ -102,13 +81,22 @@ class TestMain(unittest.TestCase):
     def test_interval_unit_case_insensitive(self, mock_open):
         mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
         with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
-            with patch.object(sys, "argv", ["handler.py", "--symbols", "600519.SH",
+            with patch.object(sys, "argv", ["handler.py", "--symbols", "000300.SH",
                                             "--interval-unit", "day",
                                             "--since-ts-millis", SINCE,
                                             "--until-ts-millis", UNTIL]):
                 handler.main()
         req = mock_open.call_args[0][0]
         self.assertIn("interval_unit=Day", req.full_url)
+
+    def test_main_rejects_empty_symbols(self):
+        with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+            with patch.object(sys, "argv", ["handler.py", "--symbols", " , ",
+                                            "--interval-unit", "Day",
+                                            "--since-ts-millis", SINCE,
+                                            "--until-ts-millis", UNTIL]):
+                with self.assertRaises(SystemExit):
+                    handler.main()
 
 
 if __name__ == "__main__":

--- a/ftshare-market-data/sub-skills/margin-trading-details/SKILL.md
+++ b/ftshare-market-data/sub-skills/margin-trading-details/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: margin-trading-details
-description: "获取融资融券明细。当用户需要获取 A 股融资融券明细列表，按融资净买入额降序排列，支持分页查询，或了解融资融券明细时使用。"
+description: "获取融资融券明细。当用户需要获取 A 股融资融券明细列表（按交易日快照），支持单日、区间或标的过滤查询，或了解融资融券明细时使用。"
 ---
 
 # 获取融资融券明细
@@ -9,84 +9,94 @@ description: "获取融资融券明细。当用户需要获取 A 股融资融券
 
 | 项目 | 说明 |
 |---|---|
-| 接口名称 | 获取融资融券明细 |
+| 接口名称 | 获取融资融券明细（margin_trading_details） |
 | 外部接口 | `/api/v1/market/data/margin-trading-details` |
 | 请求方式 | GET |
-| 适用场景 | 获取 A 股融资融券明细列表，按融资净买入额降序排列，支持分页查询 |
+| 适用场景 | 按交易日查询 A 股两融快照（每标的一行）：单日查询、指定标的的交易日区间查询、默认前一交易日快照 |
 
 ## 请求参数
 
 | 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
 |---|---|---|---|---|---|
-| `page` | int | 是 | 页码，从 1 开始 | `1` | 必须大于等于 1 |
-| `page_size` | int | 是 | 每页记录数 | `20` | 必须大于等于 1，建议不超过 100 |
+| `--date` | str | 否 | 单日查询日期 | `20260623` | 格式 `YYYYMMDD`，必须为交易日；不传返回前一交易日快照 |
+| `--start-date` | str | 否 | 区间查询开始日期 | `20260601` | 须与 `--end-date`、`--stock` **同时提供**；跨度不超过 3 年 |
+| `--end-date` | str | 否 | 区间查询结束日期 | `20260623` | 须与 `--start-date`、`--stock` 同时提供；开始须早于结束 |
+| `--stock` | str | 否 | 标的代码过滤 | `600000.SH` | 单日/默认查询时可选；区间查询时必填 |
+| `--page` | int | 否 | 页码，从 1 开始 | `1` | 默认 1 |
+| `--page_size` | int | 否 | 每页记录数 | `20` | 默认 20，最大 1000 |
+| `--all` | - | 否 | 自动翻页获取全量数据 | - | 合并 `data.records` 输出 |
 
 ## 执行方式
 
-通过根目录的 `run.py` 调用（推荐）：
-
 ```bash
-# 获取第 1 页，每页 20 条
+# 默认：前一交易日快照
 python <RUN_PY> margin-trading-details --page 1 --page_size 20
 
-# 指定分页参数
-python <RUN_PY> margin-trading-details --page 2 --page_size 50
+# 指定交易日
+python <RUN_PY> margin-trading-details --date 20260623 --page 1 --page_size 20
+
+# 单日 + 标的过滤
+python <RUN_PY> margin-trading-details --date 20260623 --stock 600000.SH
+
+# 区间查询：start_date、end_date、stock 必须同时提供
+python <RUN_PY> margin-trading-details --start-date 20260601 --end-date 20260623 --stock 600000.SH
 
 # 自动翻页获取全量数据
-python <RUN_PY> margin-trading-details --all
+python <RUN_PY> margin-trading-details --date 20260623 --all
 ```
 
 > `<RUN_PY>` 为主 `SKILL.md` 同级的 `run.py` 绝对路径，参见主 SKILL.md 的「调用方式」说明。
 
 ## 响应结构
 
+外层为 `code`（成功 200）/ `message` / `data`；分页信息与记录位于 `data`：
+
 ```json
 {
-    "items": [
-        {
-            "date": "2026-03-09",
-            "margin_trading_balance": 2440891073,
-            "margin_trading_buying_amount": 1423221922,
-            "margin_trading_repayment_amount": 874371294,
-            "securities_lending_balance_volume": 409500,
-            "securities_lending_repayment_volume": 25800,
-            "securities_lending_selling_volume": 34500,
-            "total_balance": 2453438153,
-            "symbol": "600989.SH",
-            "symbol_name": "宝丰能源"
-        }
-    ],
-    "total_pages": 99,
-    "total_items": 1970
+    "code": 200,
+    "message": "success",
+    "data": {
+        "pageNum": 1,
+        "pageSize": 20,
+        "total": 4443,
+        "pages": 223,
+        "records": [
+            {
+                "date": "2026-06-16",
+                "margin_trading_balance": 13197538116,
+                "margin_trading_buying_amount": 3827217410,
+                "margin_trading_repayment_amount": 874371294,
+                "securities_lending_balance_volume": 143377,
+                "securities_lending_repayment_volume": 25800,
+                "securities_lending_selling_volume": 34500,
+                "total_balance": 13233247592,
+                "symbol": "002384.SZ",
+                "symbol_name": "合力泰"
+            }
+        ]
+    }
 }
 ```
 
-### 顶层字段说明
-
-| 字段名 | 类型 | 是否可为空 | 说明 |
-|---|---|---|---|
-| `items` | Array | 否 | 当前页融资融券明细列表 |
-| `total_pages` | int | 否 | 总页数 |
-| `total_items` | int | 否 | 总记录数（未分页前） |
-
-### items 元素字段说明（MarginTradingDetail）
+### records 元素字段说明
 
 | 字段名 | 类型 | 是否可为空 | 说明 | 单位 |
 |---|---|---|---|---|
 | `date` | String | 否 | 交易日期，格式 `YYYY-MM-DD` | - |
-| `margin_trading_balance` | int | 否 | 融资余额 | 元 |
-| `margin_trading_buying_amount` | int | 否 | 融资买入额 | 元 |
-| `margin_trading_repayment_amount` | int | 否 | 融资偿还额 | 元 |
-| `securities_lending_balance_volume` | int | 否 | 融券余量 | 股 |
-| `securities_lending_repayment_volume` | int | 否 | 融券偿还量 | 股 |
-| `securities_lending_selling_volume` | int | 否 | 融券卖出量 | 股 |
-| `total_balance` | int | 否 | 融资融券余额 | 元 |
-| `symbol` | String | 否 | 标的代码，带市场后缀 | - |
-| `symbol_name` | String | 否 | 标的名称 | - |
+| `symbol` | String | 否 | 标的代码，短市场后缀（`600000.SH`、`000001.SZ`、`920178.BJ`） | - |
+| `symbol_name` | String | 是 | 标的名称 | - |
+| `margin_trading_balance` | int | 是 | 融资余额 | 元 |
+| `margin_trading_buying_amount` | int | 是 | 融资买入额 | 元 |
+| `margin_trading_repayment_amount` | int | 是 | 融资偿还额 | 元 |
+| `securities_lending_balance_volume` | int | 是 | 融券余量 | 股 |
+| `securities_lending_repayment_volume` | number | 是 | 融券偿还量 | 股 |
+| `securities_lending_selling_volume` | int | 是 | 融券卖出量 | 股 |
+| `total_balance` | int | 是 | 融资融券余额 | 元 |
 
 ## 注意事项
 
-- `page` 和 `page_size` 为必填项
-- 返回结果已按**融资净买入额**（`margin_trading_buying_amount - margin_trading_repayment_amount`）降序排列，无需客户端再排序
-- 如需全量数据，使用 `--all` 参数自动翻页合并，或按 `page` 递增循环至 `total_pages`
-- 金额字段单位为**元**，展示时可按需转换为万元或亿元
+- `--date` 不能与 `--start-date`/`--end-date` 同时使用；区间查询必须三参数（含 `--stock`）齐全，否则本地校验直接退出。
+- 区间包含首尾交易日，自动忽略非交易日；跨度不能超过 3 年。
+- `--stock` 支持与响应代码等价的格式（`600000.SH`、`600000.XSHG`、`600000`）；响应 `symbol` 统一为短市场后缀。
+- 金额字段单位为**元**，量字段单位为**股**，无值时为 `null`。
+- 如需全量数据，使用 `--all` 自动翻页合并，或按 `--page` 递增循环至 `data.pages`。

--- a/ftshare-market-data/sub-skills/margin-trading-details/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/margin-trading-details/scripts/handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""获取 A 股融资融券明细，支持分页与全量拉取"""
+"""获取 A 股融资融券明细，支持单日/区间查询、分页与全量拉取"""
 import argparse
 import json
 import sys
@@ -41,10 +41,49 @@ def safe_urlopen(req_or_url):
 ENDPOINT = "/api/v1/market/data/margin-trading-details"
 
 
-def fetch_page(page: int, page_size: int, date: str = None) -> dict:
+def _check_date(value, flag):
+    if len(value) != 8 or not value.isdigit():
+        print(f"{flag} 格式应为 YYYYMMDD：{value}", file=sys.stderr)
+        raise SystemExit(2)
+    return value
+
+
+def build_params(page, page_size, date, start_date, end_date, stock):
+    if page < 1:
+        print("--page 必须大于等于 1", file=sys.stderr)
+        raise SystemExit(2)
+    if page_size < 1 or page_size > 1000:
+        print("--page_size 允许范围 1~1000", file=sys.stderr)
+        raise SystemExit(2)
     params = {"page": page, "page_size": page_size}
     if date:
-        params["date"] = date
+        params["date"] = _check_date(date, "--date")
+    if start_date or end_date:
+        if date:
+            print("--date 不能与 --start-date/--end-date 同时使用", file=sys.stderr)
+            raise SystemExit(2)
+        if not (start_date and end_date and stock):
+            print("区间查询需要 --start-date、--end-date、--stock 同时提供", file=sys.stderr)
+            raise SystemExit(2)
+        _check_date(start_date, "--start-date")
+        _check_date(end_date, "--end-date")
+        if start_date >= end_date:
+            print("--start-date 必须早于 --end-date", file=sys.stderr)
+            raise SystemExit(2)
+        end_ymd = (int(end_date[:4]), int(end_date[4:6]), int(end_date[6:8]))
+        start_limit = (int(start_date[:4]) + 3, int(start_date[4:6]), int(start_date[6:8]))
+        if end_ymd > start_limit:
+            print("区间跨度不能超过 3 年", file=sys.stderr)
+            raise SystemExit(2)
+        params["start_date"] = start_date
+        params["end_date"] = end_date
+        params["stock"] = stock
+    elif stock:
+        params["stock"] = stock
+    return params
+
+
+def fetch_page(params: dict) -> dict:
     qs = urllib.parse.urlencode(params)
     url = f"{BASE_URL}{ENDPOINT}?{qs}"
     try:
@@ -60,25 +99,33 @@ def main():
     _require_api_key()
     parser = argparse.ArgumentParser(description="获取 A 股融资融券明细")
     parser.add_argument("--page", type=int, default=1, help="页码（从 1 开始）")
-    parser.add_argument("--date", type=str, default=None, help="查询日期，格式 YYYYMMDD")
-    parser.add_argument("--page_size", type=int, default=20, help="每页记录数")
+    parser.add_argument("--page_size", type=int, default=20, help="每页记录数（最大 1000）")
+    parser.add_argument("--date", type=str, default=None,
+                        help="单日查询日期，格式 YYYYMMDD，必须为交易日；不传返回前一交易日快照")
+    parser.add_argument("--start-date", dest="start_date", type=str, default=None,
+                        help="区间查询开始日期 YYYYMMDD；须与 --end-date、--stock 同时提供")
+    parser.add_argument("--end-date", dest="end_date", type=str, default=None,
+                        help="区间查询结束日期 YYYYMMDD；须与 --start-date、--stock 同时提供，跨度不超过 3 年")
+    parser.add_argument("--stock", type=str, default=None,
+                        help="标的代码过滤，如 600000.SH；区间查询时必填")
     parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
     args = parser.parse_args()
 
+    params = build_params(args.page, args.page_size, args.date,
+                          args.start_date, args.end_date, args.stock)
+
     if args.fetch_all:
-        first = fetch_page(1, args.page_size, args.date)
-        all_items = list(first.get("items", []))
-        total_pages = first.get("total_pages", 1)
-        for p in range(2, total_pages + 1):
-            page_data = fetch_page(p, args.page_size, args.date)
-            all_items.extend(page_data.get("items", []))
-        result = {
-            "items": all_items,
-            "total_pages": total_pages,
-            "total_items": first.get("total_items", len(all_items)),
-        }
+        first = fetch_page(params)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        pages = data.get("pages", 1)
+        for p in range(2, pages + 1):
+            page_params = dict(params, page=p)
+            page_data = fetch_page(page_params)
+            records.extend((page_data.get("data") or {}).get("records", []))
+        result = {"records": records, "pages": pages, "total": data.get("total", len(records))}
     else:
-        result = fetch_page(args.page, args.page_size, args.date)
+        result = fetch_page(params)
 
     print(json.dumps(result, ensure_ascii=False, indent=2))
 

--- a/ftshare-market-data/sub-skills/margin-trading-details/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/margin-trading-details/scripts/test_handler.py
@@ -1,51 +1,96 @@
 #!/usr/bin/env python3
 """Tests for margin-trading-details handler"""
 import json
+import os
 import sys
 import unittest
 import urllib.error
 from io import BytesIO, StringIO
 from unittest.mock import patch
 
-# Import the module under test by executing it
-sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import importlib.util
-spec = importlib.util.spec_from_file_location("handler", __import__("os").path.join(__import__("os").path.dirname(__import__("os").path.abspath(__file__)), "handler.py"))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(os.path.dirname(os.path.abspath(__file__)), "handler.py"))
 handler = importlib.util.module_from_spec(spec)
+
+ENVELOPE = b'{"code":200,"message":"success","data":{"pageNum":1,"pageSize":2,"total":16,"pages":8,"records":[{"symbol":"600000.SH"}]}}'
+
+
+class TestBuildParams(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_default_params(self):
+        params = handler.build_params(1, 20, None, None, None, None)
+        self.assertEqual(params, {"page": 1, "page_size": 20})
+
+    def test_date_query(self):
+        params = handler.build_params(1, 20, "20260623", None, None, None)
+        self.assertEqual(params["date"], "20260623")
+
+    def test_date_with_stock(self):
+        params = handler.build_params(1, 20, "20260623", None, None, "600000.SH")
+        self.assertEqual(params["date"], "20260623")
+        self.assertEqual(params["stock"], "600000.SH")
+
+    def test_range_query(self):
+        params = handler.build_params(1, 20, None, "20260601", "20260623", "600000.SH")
+        self.assertEqual(params["start_date"], "20260601")
+        self.assertEqual(params["end_date"], "20260623")
+        self.assertEqual(params["stock"], "600000.SH")
+        self.assertNotIn("date", params)
+
+    def test_rejects_date_with_range(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, "20260623", "20260601", "20260623", "600000.SH")
+
+    def test_rejects_incomplete_range(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, None, "20260601", None, None)
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, None, "20260601", "20260623", None)
+
+    def test_rejects_start_after_end(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, None, "20260623", "20260601", "600000.SH")
+
+    def test_rejects_span_over_three_years(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, None, "20200101", "20260623", "600000.SH")
+
+    def test_allows_exactly_three_years(self):
+        params = handler.build_params(1, 20, None, "20230623", "20260623", "600000.SH")
+        self.assertEqual(params["start_date"], "20230623")
+
+    def test_rejects_bad_date_format(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 20, "2026-06-23", None, None, None)
+
+    def test_rejects_page_size_out_of_range(self):
+        with self.assertRaises(SystemExit):
+            handler.build_params(1, 1001, None, None, None, None)
 
 
 class TestFetchPage(unittest.TestCase):
     def setUp(self):
-        # Reload handler to get fresh state
         spec.loader.exec_module(handler)
 
     @patch.object(handler, "safe_urlopen")
-    def test_url_without_date(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b'{"items": [], "total_pages": 1, "total_items": 0}'
-        handler.fetch_page(2, 200)
+    def test_url_contains_params(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = ENVELOPE
+        handler.fetch_page({"page": 2, "page_size": 200, "date": "20260623"})
         called_url = mock_open.call_args[0][0]
+        self.assertIn("/api/v1/market/data/margin-trading-details", called_url)
         self.assertIn("page=2", called_url)
         self.assertIn("page_size=200", called_url)
-        self.assertNotIn("date=", called_url)
-
-    @patch.object(handler, "safe_urlopen")
-    def test_url_with_date(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = b'{"items": [], "total_pages": 1, "total_items": 0}'
-        handler.fetch_page(2, 200, "20200103")
-        called_url = mock_open.call_args[0][0]
-        self.assertIn("page=2", called_url)
-        self.assertIn("page_size=200", called_url)
-        self.assertIn("date=20200103", called_url)
+        self.assertIn("date=20260623", called_url)
 
     @patch.object(handler, "safe_urlopen")
     def test_returns_parsed_json(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            b'{"items": [{"symbol": "600000.SH"}], "total_pages": 5, "total_items": 100}'
-        )
-        result = handler.fetch_page(1, 1)
-        self.assertEqual(len(result["items"]), 1)
-        self.assertEqual(result["items"][0]["symbol"], "600000.SH")
-        self.assertEqual(result["total_pages"], 5)
+        mock_open.return_value.__enter__.return_value.read.return_value = ENVELOPE
+        result = handler.fetch_page({"page": 1, "page_size": 2})
+        self.assertEqual(result["data"]["records"][0]["symbol"], "600000.SH")
+        self.assertEqual(result["data"]["pages"], 8)
 
     @patch.object(handler, "safe_urlopen")
     def test_http_error_exits(self, mock_open):
@@ -53,7 +98,7 @@ class TestFetchPage(unittest.TestCase):
             "http://fake", 500, "Internal Error", {}, BytesIO(b"server error")
         )
         with self.assertRaises(SystemExit):
-            handler.fetch_page(1, 20)
+            handler.fetch_page({"page": 1, "page_size": 20})
 
 
 class TestMain(unittest.TestCase):
@@ -62,49 +107,47 @@ class TestMain(unittest.TestCase):
 
     @patch.object(handler, "safe_urlopen")
     def test_single_page(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            b'{"items": [{"symbol": "000001.SZ"}], "total_pages": 3, "total_items": 50}'
-        )
-        with patch.object(sys, "argv", ["handler.py", "--page", "1", "--page_size", "20"]):
-            with patch("sys.stdout", new_callable=StringIO) as fake_out:
-                handler.main()
-                result = json.loads(fake_out.getvalue())
-                self.assertEqual(result["total_pages"], 3)
+        mock_open.return_value.__enter__.return_value.read.return_value = ENVELOPE
+        with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+            with patch.object(sys, "argv", ["handler.py", "--page", "1", "--page_size", "2"]):
+                with patch("sys.stdout", new_callable=StringIO) as fake_out:
+                    handler.main()
+                    result = json.loads(fake_out.getvalue())
+                    self.assertEqual(result["code"], 200)
+                    self.assertEqual(result["data"]["total"], 16)
 
     @patch.object(handler, "safe_urlopen")
-    def test_single_page_with_date(self, mock_open):
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            b'{"items": [], "total_pages": 1, "total_items": 0}'
-        )
-        with patch.object(sys, "argv", ["handler.py", "--page", "1", "--page_size", "200", "--date", "20200103"]):
-            handler.main()
-            called_url = mock_open.call_args[0][0]
-            self.assertIn("date=20200103", called_url)
+    def test_range_query_flags(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = ENVELOPE
+        with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+            with patch.object(sys, "argv", ["handler.py", "--start-date", "20260601",
+                                            "--end-date", "20260623", "--stock", "600000.SH"]):
+                handler.main()
+        called_url = mock_open.call_args[0][0]
+        self.assertIn("start_date=20260601", called_url)
+        self.assertIn("end_date=20260623", called_url)
+        self.assertIn("stock=600000.SH", called_url)
 
     @patch.object(handler, "safe_urlopen")
     def test_fetch_all_pagination(self, mock_open):
-        page1 = b'{"items": [{"symbol": "A"}, {"symbol": "B"}], "total_pages": 2, "total_items": 3}'
-        page2 = b'{"items": [{"symbol": "C"}], "total_pages": 2, "total_items": 3}'
+        page1 = b'{"data":{"records":[{"symbol":"A"},{"symbol":"B"}],"pages":2,"total":3}}'
+        page2 = b'{"data":{"records":[{"symbol":"C"}],"pages":2,"total":3}}'
         mock_open.return_value.__enter__.return_value.read.side_effect = [page1, page2]
 
-        with patch.object(sys, "argv", ["handler.py", "--page_size", "2", "--all"]):
-            with patch("sys.stdout", new_callable=StringIO) as fake_out:
-                handler.main()
-                result = json.loads(fake_out.getvalue())
-                self.assertEqual(len(result["items"]), 3)
-                self.assertEqual(result["total_pages"], 2)
-                self.assertEqual(result["total_items"], 3)
+        with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+            with patch.object(sys, "argv", ["handler.py", "--page_size", "2", "--all"]):
+                with patch("sys.stdout", new_callable=StringIO) as fake_out:
+                    handler.main()
+                    result = json.loads(fake_out.getvalue())
+                    self.assertEqual(len(result["records"]), 3)
+                    self.assertEqual(result["pages"], 2)
+                    self.assertEqual(result["total"], 3)
 
-    @patch.object(handler, "safe_urlopen")
-    def test_fetch_all_with_date(self, mock_open):
-        page1 = b'{"items": [{"symbol": "A"}], "total_pages": 2, "total_items": 2}'
-        page2 = b'{"items": [{"symbol": "B"}], "total_pages": 2, "total_items": 2}'
-        mock_open.return_value.__enter__.return_value.read.side_effect = [page1, page2]
-
-        with patch.object(sys, "argv", ["handler.py", "--all", "--date", "20200103"]):
-            handler.main()
-            for call in mock_open.call_args_list:
-                self.assertIn("date=20200103", call[0][0])
+    def test_main_rejects_incomplete_range(self):
+        with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+            with patch.object(sys, "argv", ["handler.py", "--start-date", "20260601"]):
+                with self.assertRaises(SystemExit):
+                    handler.main()
 
 
 class TestSafeUrlopen(unittest.TestCase):

--- a/ftshare-market-data/sub-skills/stock-announcements/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-announcements/SKILL.md
@@ -12,5 +12,5 @@ description: 查询 A 股公告列表。按 stock-code 或日期范围查询，p
 ## 调用示例
 
 ```bash
-python <RUN_PY> stock-announcements --start-date 20260828 --page 1 --page-size 5
+python <RUN_PY> stock-announcements --start-date 20260908 --page 1 --page-size 5
 ```

--- a/ftshare-market-data/sub-skills/stock-candlesticks-batch/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-candlesticks-batch/SKILL.md
@@ -1,59 +1,61 @@
 ---
 name: stock-candlesticks-batch
-description: 批量获取多只股票/ETF/可转债/指数 K 线 GET 接口（market.ft.tech，stock-candlesticks/batch）。用户问多只标的的 K 线、批量日 K/周 K/月 K/年 K、混合多类证券的 K 线时使用。必填 --symbols、--interval-unit、--until-ts-millis；可选 --interval-value、--adjust-kind、--since-ts-millis、--limit。
+description: 批量获取多只股票/ETF/可转债/指数 K 线 GET 接口（market.ft.tech，stock-candlesticks/batch）。用户问多只标的的日/周/月/年 K 线、批量开高低收、混合多类证券的 K 线时使用。必填 --symbols、--interval-unit、--since-ts-millis、--until-ts-millis；可选 --adjust-kind、--limit。
 ---
 
-# 批量股票 K 线 - 批量查询多只标的 K 线（stock-candlesticks/batch）
+# 批量股票K线
 
 ## 1. 接口描述
 
 | 项目 | 说明 |
 |------|------|
-| 接口名称 | 批量查询多只标的 K 线（通用） |
+| 接口名称 | 批量股票K线（stock_candlesticks_batch） |
 | 外部接口 | `GET /api/v2/market/data/stock-candlesticks/batch` |
-| 请求方式 | GET（query 参数） |
-| 适用场景 | 一次拉取股票 / ETF / 可转债 / 指数等多只标的的分/日/周/月/年 K 线。响应为嵌套数组 `[[symbol, K线数组], ...]`。通用语义，允许不同证券类别混合查询 |
+| 请求方式 | GET（query 参数，`symbols` 可重复传入） |
+| 适用场景 | 一次批量查询股票 / ETF / 可转债 / 指数等多只标的的历史 K 线（开高低收、成交量、成交额、换手率），支持日/周/月/年周期与前复权/后复权。通用语义，允许不同证券类别混合查询，不做类别校验 |
 
 ## 2. 请求参数
 
 | 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
 |--------|------|----------|------|----------|------|
-| symbols | string[] | 是 | 标的代码列表 | 600519.SH,510300.SH,113027.SH,000300.SH | 逗号分隔；可混合股票/ETF/可转债/指数 |
-| interval_unit | string | 是 | 周期单位 | Day | Minute/Day/Week/Month/Year |
-| interval_value | int | 否 | 间隔数值 | 1 | 默认 1；Minute+5 表示 5 分钟 K 线 |
+| symbols | string[] | 是 | 标的代码列表，逗号分隔传给 CLI | 600519.SH,510300.SH,113027.SH,000300.SH | 可混合股票/ETF/可转债/指数；沪市 `.XSHG`/`.SH`、深市 `.XSHE`/`.SZ`、北交所 `.BJSE`/`.BJ`；接口侧以重复 query 参数发送 |
+| interval_unit | string | 是 | 周期单位 | Day | Day/Week/Month/Year，大小写不敏感；**不支持 Minute** |
 | adjust_kind | string | 否 | 复权类型 | Forward | None（默认）/Forward（前复权）/Backward（后复权） |
-| since_ts_millis | int | 否 | 开始时间戳（毫秒） | 1756700000000 | 分钟 K 线与 until 跨度 ≤3 天 |
+| since_ts_millis | int | 是 | 开始时间戳（毫秒） | 1756431000000 | 与 until 的跨度不得超过 12 个日历月；不得晚于 until |
 | until_ts_millis | int | 是 | 结束时间戳（毫秒） | 1756791000000 | - |
-| limit | int | 否 | 每个标的返回条数上限 | 2 | 未传 since 和 limit 时每个标的默认最多返回 50 根 |
+| limit | int | 否 | 每个标的返回条数上限 | 3 | 不传时返回请求时间范围内的全部数据 |
 
 ## 3. 响应说明
 
-响应为二元数组列表，每项结构为 `[symbol, K线数组]`：
+外层固定为 `code`（成功 200）/ `message`（成功 `success`）/ `data`（失败时为 `null`）。`data` 为非分页嵌套数组，外层每项为 `[symbol, K线数组]`，每根 K 线字段：
 
-| 字段名 | 类型 | 说明 |
-|--------|------|------|
-| [0] | string | 标的代码；响应统一使用长市场后缀（`.XSHG`/`.XSHE`/`.BJSE`） |
-| [1] | array | 该标的的 K 线数组，字段同单只接口 |
+| 字段名 | 类型 | 说明 | 单位 |
+|--------|------|------|------|
+| symbol | string | 标的代码，响应统一使用 `.SH`、`.SZ`、`.BJ` 短后缀 | - |
+| open / high / low / close | number | 开/高/低/收盘价 | 元 |
+| ts_millis | string | 收盘时间戳 | 毫秒 |
+| ts_millis_open | string | 开盘时间戳 | 毫秒 |
+| turnover | number | 成交额 | 元 |
+| volume | integer | 成交量 | - |
+| turnover_rate | number | 换手率 | % |
 
-K 线单根字段同 `stock-candlesticks`：open / high / low / close / ts_millis / ts_millis_open / turnover / volume。
+注：`open/high/low/close`、`turnover` 在 JSON 中实际以字符串返回（避免精度丢失）；`ts_millis` 为数字。
 
 ## 4. 调用方式
 
 ```bash
-python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,000001.SZ --interval-unit Day --since-ts-millis 1756700000000 --until-ts-millis 1756791000000 --limit 2
-python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,510300.SH,113027.SH --interval-unit Week --adjust-kind Forward --until-ts-millis 1756791000000 --limit 4
+python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,000001.SZ --interval-unit Day --since-ts-millis 1756431000000 --until-ts-millis 1756791000000 --limit 2
+python <RUN_PY> stock-candlesticks-batch --symbols 600519.SH,510300.SH,113027.SH --interval-unit Week --adjust-kind Forward --since-ts-millis 1756431000000 --until-ts-millis 1756791000000 --limit 3
 ```
 
-`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON，请求头已内置 `X-Client-Name: ft-claw`。
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
 
 ## 5. 注意事项
 
-- `symbols`、`interval_unit`、`until_ts_millis` 必填。
-- `symbols` 用逗号分隔；可混合不同证券类别，不做类别校验。
-- 响应中的 `symbol` 会规范化为长市场后缀。
-- 分钟 K 线（`interval_unit=Minute`）的 `since/until` 跨度硬限制 ≤3 天。
-- `interval_value` 仅在 `interval_unit=Minute` 时生效：不传或传 1 为 1 分钟 K，传 5/15/30/60/120 为对应多分钟 K；其他周期忽略该字段。
-- 多分钟 K 按北京时间的每个交易日分别聚合，不跨交易日；以 5 分钟 K 为例，首根为 09:30—09:35，开高低收取区间首根开盘价、最高价、最低价、末根收盘价，成交量和成交额按区间求和。
-- 默认不复权（None），`Forward` 前复权、`Backward` 后复权。
-- 价格字段 JSON 中为字符串以避免精度丢失。
-- 如仅需单类标的批量查询，推荐使用对应的专用批量接口（`etf-candlesticks-batch` / `convertible-bond-candlesticks-batch` / `index-candlesticks-batch`）。
+- `symbols`、`interval_unit`、`since_ts_millis`、`until_ts_millis` 必填；所有 `symbols` 使用相同周期。
+- 接口仅支持 GET；`symbols` 在查询参数中以重复参数形式发送（`symbols=600519.SH&symbols=000001.SZ`）。
+- 时间跨度最多 12 个日历月；需要更长历史时按窗口分段多次调用。
+- 不支持分钟 K 线；分钟数据请使用 `stock-minutes-batch` 子 skill。
+- 混合证券类别不做校验；换手率仅股票标的有值，ETF/可转债/指数标的当前为 `null`。
+- 输入 `.XSHG`/`.XSHE`/`.BJSE` 长后缀时，响应中的 symbol 会规范化为 `.SH`、`.SZ`、`.BJ` 短后缀。
+- 默认不复权（None）；仅使用历史日 K 数据计算，不含实时行情，实际起始日期以行情数据源覆盖为准。

--- a/ftshare-market-data/sub-skills/stock-candlesticks/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-candlesticks/SKILL.md
@@ -42,6 +42,7 @@ description: 单只股票/ETF/指数/可转债历史 K 线 GET 接口（market.f
 | ts_millis_open | int | 开盘时间戳 | 毫秒 |
 | turnover | string | 成交额 | 元 |
 | volume | int64 | 成交量 | 股/份 |
+| turnover_rate | number | 换手率 | % |
 
 ## 4. 调用方式
 

--- a/ftshare-market-data/sub-skills/stock-dividends-effective/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-dividends-effective/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: stock-dividends-effective
+description: 查询 A 股已实施（有效）分红记录（stock_dividends_effective）。用户问已实施分红、每股派息、送股、转增、除权除息日、股权登记日、现金到账日、分红公告链接时使用。
+---
+
+# 股票有效分红记录
+
+## 1. 接口描述
+
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 股票有效分红记录（stock_dividends_effective） |
+| 外部接口 | `GET /api/v2/market/data/stock-dividends-effective` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 查询 A 股已实施分红记录（派息、送股、转增）分页视图，可按标的和公告日期范围筛选 |
+
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| symbol | string | 否 | 标的代码 | 600519.XSHG | 支持带交易所后缀；不传返回全市场 |
+| since_date | string | 成对 | 开始公告日期 | 2026-05-26 | 格式 `YYYY-MM-DD`，按 `ann_date` 筛选 |
+| until_date | string | 成对 | 结束公告日期 | 2026-05-26 | 与 `since_date` 成对且不早于开始日期 |
+| page | int | 否 | 页码 | 1 | 从 1 开始，默认 1 |
+| page_size | int | 否 | 每页条数 | 50 | 默认 50，最大 200 |
+| --all | - | 否 | 自动翻页拉全量 | - | 仅本子 skill 扩展参数 |
+
+## 3. 响应说明
+
+外层固定为 `code` / `message` / `data`。`data` 为分页对象：`pageNum` / `pageSize` / `total` / `pages` / `records`。
+
+records 元素：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| symbol | string | 标的代码（规范化为短后缀，如 `600519.SH`） |
+| ann_date | string | 公告日期 |
+| reporting_period | string | 分红所属报告期 |
+| cash_dividend_ratio | string | 每股税前现金分红 |
+| bonus_issue_ratio | string | 每股送股比例 |
+| bonus_issue_from_capital_reserves_ratio | string | 每股转增比例 |
+| ex_dividend_date | string / null | 除权除息日 |
+| record_date | string / null | 股权登记日 |
+| payout_date | string / null | 现金到账日 |
+| share_listing_date | string / null | 送转股上市流通日 |
+| ann_url | string / null | 公告链接 |
+| total_cash_dividend_ratio | string / null | 同一股票同一除权日综合每股税前现金分红 |
+| total_bonus_issue_ratio | string / null | 同一股票同一除权日综合每股送股比例 |
+| total_bonus_issue_from_capital_reserves_ratio | string / null | 同一股票同一除权日综合每股转增比例 |
+
+## 4. 调用方式
+
+```bash
+python <RUN_PY> stock-dividends-effective --symbol 600519.XSHG --page 1 --page-size 1
+python <RUN_PY> stock-dividends-effective --symbol 002043.SZ --since-date 2026-05-26 --until-date 2026-05-26
+python <RUN_PY> stock-dividends-effective --all
+```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 只返回已实施的分红记录；未实施或已取消的不返回。
+- 同一股票同一除权日可能返回多条记录；三个 `total_*` 字段为该组合计，组内各条记录取值相同。
+- 输入代码会规范化为带交易所后缀的 `symbol`，例如输入 `600519.XSHG` 返回 `600519.SH`。
+- 日期按公告日期 `ann_date` 筛选，不限制日期跨度；`since_date` / `until_date` 必须成对传入（handler 会本地校验并拒绝）。
+- `--all` 会按 `pages` 自动翻页，把所有 `records` 合并为一个数组返回。

--- a/ftshare-market-data/sub-skills/stock-dividends-effective/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/stock-dividends-effective/scripts/handler.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""股票有效分红记录（GET /api/v2/market/data/stock-dividends-effective）"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+
+def _require_api_key():
+    key = os.environ.get("FTSHARE_API_KEY")
+    if not key:
+        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr)
+        raise SystemExit(2)
+    return key
+
+
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+ENDPOINT = "/api/v2/market/data/stock-dividends-effective"
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    base_parsed = urllib.parse.urlparse(BASE_URL)
+    if parsed.scheme != base_parsed.scheme or parsed.netloc != base_parsed.netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(req_or_url, urllib.request.Request):
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    if isinstance(req_or_url, urllib.request.Request):
+        for key, value in _REQUEST_HEADERS.items():
+            req_or_url.add_unredirected_header(key, value)
+    else:
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def build_params(args):
+    params = {}
+    if args.symbol is not None:
+        params["symbol"] = args.symbol
+    if args.since_date is not None:
+        params["since_date"] = args.since_date
+    if args.until_date is not None:
+        params["until_date"] = args.until_date
+    params["page"] = args.page
+    params["page_size"] = args.page_size
+    return params
+
+
+def fetch_page(params):
+    query = urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        f"{BASE_URL}{ENDPOINT}?{query}",
+        headers={**HEADERS, **_REQUEST_HEADERS},
+        method="GET",
+    )
+    try:
+        with safe_urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    _require_api_key()
+    parser = argparse.ArgumentParser(description="A 股已实施分红记录（派息、送股、转增）分页查询")
+    parser.add_argument("--symbol", default=None,
+                        help="标的代码，支持带交易所后缀，如 600519.XSHG、000028.SZ；不传返回全市场")
+    parser.add_argument("--since-date", dest="since_date", default=None,
+                        help="开始公告日期 YYYY-MM-DD；与 --until-date 成对传入")
+    parser.add_argument("--until-date", dest="until_date", default=None,
+                        help="结束公告日期 YYYY-MM-DD；与 --since-date 成对传入")
+    parser.add_argument("--page", type=int, default=1, help="页码，从 1 开始，默认 1")
+    parser.add_argument("--page-size", dest="page_size", type=int, default=50,
+                        help="每页条数，默认 50，最大 200")
+    parser.add_argument("--all", action="store_true", dest="fetch_all", help="自动翻页获取全量数据")
+    args = parser.parse_args()
+
+    if (args.since_date is None) != (args.until_date is None):
+        print("--since-date 与 --until-date 必须成对传入", file=sys.stderr)
+        raise SystemExit(2)
+
+    params = build_params(args)
+    if args.fetch_all:
+        first = fetch_page(params)
+        data = first.get("data") or {}
+        records = list(data.get("records", []))
+        total_pages = data.get("pages") or 1
+        for page in range(2, total_pages + 1):
+            page_data = fetch_page({**params, "page": page})
+            records.extend((page_data.get("data") or {}).get("records", []))
+        result = {
+            "records": records,
+            "pages": total_pages,
+            "total": data.get("total", len(records)),
+        }
+    else:
+        result = fetch_page(params)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/stock-dividends-effective/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/stock-dividends-effective/scripts/test_handler.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for stock-dividends-effective handler"""
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            with patch("sys.stdout", new_callable=StringIO) as out:
+                handler.main()
+                return json.loads(out.getvalue())
+
+
+class TestParams(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    def test_rejects_unpaired_dates(self):
+        with self.assertRaises(SystemExit):
+            _run(["--since-date", "2026-05-26", "--page", "1", "--page-size", "5"])
+        with self.assertRaises(SystemExit):
+            _run(["--until-date", "2026-05-26", "--page", "1", "--page-size", "5"])
+
+    @patch.object(handler, "safe_urlopen")
+    def test_query_mapping(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = (
+            b'{"code":200,"data":{"records":[],"pages":1,"total":0}}'
+        )
+        _run(["--symbol", "002043.SZ", "--since-date", "2026-05-26",
+              "--until-date", "2026-05-26", "--page", "1", "--page-size", "5"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v2/market/data/stock-dividends-effective", req.full_url)
+        self.assertIn("symbol=002043.SZ", req.full_url)
+        self.assertIn("since_date=2026-05-26", req.full_url)
+        self.assertIn("until_date=2026-05-26", req.full_url)
+
+
+class TestFetchAll(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_all_aggregates_pages(self, mock_open):
+        page1 = {"code": 200, "data": {"records": [{"symbol": "600519.SH"}], "pages": 2, "total": 2}}
+        page2 = {"code": 200, "data": {"records": [{"symbol": "000028.SZ"}], "pages": 2, "total": 2}}
+        mock_open.return_value.__enter__.return_value.read.side_effect = [
+            json.dumps(page1).encode(), json.dumps(page2).encode(),
+        ]
+        result = _run(["--page", "1", "--page-size", "1", "--all"])
+        self.assertEqual(len(result["records"]), 2)
+        self.assertEqual(result["total"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/stock-history-list/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-history-list/SKILL.md
@@ -7,6 +7,8 @@ description: 按交易日查询股票历史行情截面列表。必填 --trade-d
 
 按交易日查询 A 股主板股票历史行情截面。接口：GET `/api/v1/market/data/stock-history-list`。
 
+注意：`region_sector`、`cum_adjust_factor` 不可用；`pe_ttm`、`concept_sectors` 仅 2026 年起有数据。
+
 ## 参数
 
 - `--trade-date`：必填，交易日，格式 `YYYYMMDD`。

--- a/ftshare-market-data/sub-skills/stock-history-list/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-history-list/SKILL.md
@@ -21,6 +21,6 @@ description: 按交易日查询股票历史行情截面列表。必填 --trade-d
 所有请求必须设置环境变量 `FTSHARE_API_KEY`；handler 将其作为 `FTSHARE_API_KEY` 请求头发送，并设置 `Content-Type: application/json`。缺失凭据时不会发起请求。
 
 ```bash
-python <RUN_PY> stock-history-list --trade-date 20260829 --page 1 --page-size 5
-python <RUN_PY> stock-history-list --trade-date 20260829 --code 600000.SH --page 1 --page-size 5
+python <RUN_PY> stock-history-list --trade-date 20260909 --page 1 --page-size 5
+python <RUN_PY> stock-history-list --trade-date 20260909 --code 600000.SH --page 1 --page-size 5
 ```

--- a/ftshare-market-data/sub-skills/stock-minutes-batch/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-minutes-batch/SKILL.md
@@ -8,7 +8,7 @@ description: 批量查询 股票历史分钟 K 线。用户询问多只股票的
 接口：`GET /api/v2/market/data/stock_minutes/batch`。必填 `--symbols`、`--since-ts-millis`、`--until-ts-millis`；`--symbols` 使用逗号分隔，最多 20 只；可选 `--interval-value`、`--limit`，时间跨度不超过 3 天，`limit` 范围 1~1000。
 
 ```bash
-python <RUN_PY> stock-minutes-batch --symbols 000300.SH,399001.SZ --since-ts-millis 1787189400000 --until-ts-millis 1787191200000 --limit 5
+python <RUN_PY> stock-minutes-batch --symbols 600519.SH,000001.SZ --since-ts-millis 1788919020000 --until-ts-millis 1788920820000 --limit 5
 ```
 
-返回 `code/message/data`，`data` 为每只标的的 `symbol`、`total` 和 `items` 列表；不是分页接口。
+返回 `code/message/data`，`data` 为每只标的的 `symbol`、`total` 和 `items` 列表；不是分页接口。每根 K 线字段：open / high / low / close / ts_millis / ts_millis_open / turnover / volume / turnover_rate（换手率）。

--- a/ftshare-market-data/sub-skills/stock-minutes/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-minutes/SKILL.md
@@ -18,3 +18,5 @@ python <RUN_PY> stock-minutes --symbol 000001.SZ --since-ts-millis 1787189400000
 ```
 
 接口返回 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+响应为数组结构（非分页），每根 K 线字段：open / high / low / close / ts_millis / ts_millis_open / turnover / volume / turnover_rate（换手率）。

--- a/ftshare-market-data/sub-skills/stock-realtime-day-kline/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-realtime-day-kline/SKILL.md
@@ -7,6 +7,8 @@ description: 查询股票当前交易日实时日 K 线。必填 --symbols，按
 
 查询股票当前交易日实时日 K 线。必填 --symbols，按空格分隔。接口：GET /api/v4/market/data/stock-realtime-day-kline。
 
+每根 K 线字段：symbol / open / high / low / close / ts_millis / ts_millis_open / turnover / volume / turnover_rate（换手率），返回当前交易日截至最新行情时刻的数据。
+
 所有请求必须设置环境变量 `FTSHARE_API_KEY`；handler 将其作为 `FTSHARE_API_KEY` 请求头发送。缺失凭据时不会发起请求。
 
 通过主目录 `run.py` 调用：

--- a/ftshare-market-data/sub-skills/stock-realtime-minute-kline/SKILL.md
+++ b/ftshare-market-data/sub-skills/stock-realtime-minute-kline/SKILL.md
@@ -7,6 +7,8 @@ description: 查询股票当前交易日实时 1 分钟 K 线。必填 --symbols
 
 查询股票当前交易日实时 1 分钟 K 线。必填 --symbols，按空格分隔，单次最多 20 个。接口：GET /api/v4/market/data/stock-realtime-minute-kline。
 
+每根 K 线字段：symbol / open / high / low / close / ts_millis / ts_millis_open / turnover / volume / turnover_rate（换手率）。
+
 所有请求必须设置环境变量 `FTSHARE_API_KEY`；handler 将其作为 `FTSHARE_API_KEY` 请求头发送。缺失凭据时不会发起请求。
 
 通过主目录 `run.py` 调用：

--- a/ftshare-market-data/sub-skills/ths-concept-daily-flow/SKILL.md
+++ b/ftshare-market-data/sub-skills/ths-concept-daily-flow/SKILL.md
@@ -1,16 +1,44 @@
 ---
 name: ths-concept-daily-flow
-description: 查询同花顺概念板块资金流日度。接口：GET /api/v1/market/data/ths-concept-daily-flow。所有请求必须设置 FTSHARE_API_KEY。
+description: 查询同花顺概念板块资金流日度。用户问同花顺概念板块资金流、概念板块每日净流入、概念板块主力流入、龙头股涨跌幅时使用。
 ---
 
 # 同花顺概念板块资金流日度
 
-接口：GET `/api/v1/market/data/ths-concept-daily-flow`。参数和响应以 `ftshare-doc/api-doc/股票数据/资金流向数据/同花顺概念板块资金流日度.md` 为准。
+## 1. 接口描述
 
-请求必须从环境变量 `FTSHARE_API_KEY` 读取凭据，并通过请求头发送 `FTSHARE_API_KEY` 和 `Content-Type: application/json`；缺少凭据时不会发起请求。
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 同花顺概念板块资金流日度 |
+| 外部接口 | `GET /api/v1/market/data/ths-concept-daily-flow` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按日期范围查询同花顺概念板块日度资金流，含板块指数、涨跌幅、流入/流出/净额、领涨股及涨跌幅 |
 
-## 调用示例
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| start_date | string | 否 | 开始日期 | 20260805 | YYYYMMDD |
+| end_date | string | 否 | 结束日期 | 20260805 | YYYYMMDD |
+| board_name | string | 否 | 概念板块名称，精确匹配 | 机器人概念 | 不能是空白字符串；不传返回日期范围内全部概念板块 |
+| page | int | 否 | 页码 | 1 | - |
+| page_size | int | 否 | 每页条数 | 100 | - |
+
+## 3. 响应说明
+
+返回分页结构。records 元素核心字段：`board_name`（概念板块名称）、`trade_date`、`board_index`（板块指数，可为 null）、`change_pct`、`company_count`、`inflow`、`outflow`、`net_amount`、`leader_name`、`leader_change_pct`、`leader_price`。
+
+## 4. 调用方式
 
 ```bash
-python <RUN_PY> ths-concept-daily-flow --start_date 20260828 --end_date 20260828 --page 1 --trade_date 20260828
+python <RUN_PY> ths-concept-daily-flow --start-date 20260805 --end-date 20260805 --board-name 机器人概念 --page 1 --page-size 100
+python <RUN_PY> ths-concept-daily-flow --start-date 20260801 --end-date 20260805 --page 1 --page-size 100
 ```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 板块名称参数为 `board_name`（原 `sector_name` 已更名，不再使用旧参数名），输出字段同步为 `board_name` / `board_index`。
+- 结果按 `trade_date` 降序、`board_name` 升序排列。
+- 源数据缺项返回 `null`，接口不做聚合、单位转换或缺失值补算。

--- a/ftshare-market-data/sub-skills/ths-concept-daily-flow/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/ths-concept-daily-flow/scripts/handler.py
@@ -1,67 +1,99 @@
 #!/usr/bin/env python3
-import argparse, json, os, sys, urllib.error, urllib.parse, urllib.request
-BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
-ENDPOINT = '/api/v1/market/data/ths-concept-daily-flow'
-SAFE_URLOPENER = urllib.request.build_opener()
-_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+"""同花顺概念板块资金流日度（GET /api/v1/market/data/ths-concept-daily-flow）"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+
 def _require_api_key():
     key = os.environ.get("FTSHARE_API_KEY")
     if not key:
-        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr); raise SystemExit(2)
+        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr)
+        raise SystemExit(2)
     return key
-def safe_urlopen(request, timeout=30):
-    url = request.full_url if isinstance(request, urllib.request.Request) else str(request)
-    parsed, base = urllib.parse.urlparse(url), urllib.parse.urlparse(BASE_URL)
-    if parsed.scheme != base.scheme or parsed.netloc != base.netloc:
-        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr); raise SystemExit(1)
-    if not isinstance(request, urllib.request.Request): request = urllib.request.Request(url, method="GET")
-    request.add_unredirected_header("FTSHARE_API_KEY", _require_api_key())
-    request.add_unredirected_header("Content-Type", "application/json")
-    return SAFE_URLOPENER.open(request, timeout=timeout)
-def main():
-    key = _require_api_key(); parser = argparse.ArgumentParser(description='同花顺概念板块资金流日度')
-    parser.add_argument("--start_date", required=True)
-    parser.add_argument("--end_date", required=True)
-    parser.add_argument("--sector_name")
-    parser.add_argument("--page")
-    parser.add_argument("--page_size")
-    parser.add_argument("--total", required=False)
-    parser.add_argument("--trade_date", required=True)
-    parser.add_argument("--sector_index", required=False)
-    parser.add_argument("--change_pct", required=False)
-    parser.add_argument("--company_count", required=False)
-    parser.add_argument("--inflow", required=False)
-    parser.add_argument("--outflow", required=False)
-    parser.add_argument("--net_amount", required=False)
-    parser.add_argument("--leader_name", required=False)
-    parser.add_argument("--leader_change_pct", required=False)
-    parser.add_argument("--leader_price", required=False)
-    args = parser.parse_args()
+
+
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+ENDPOINT = "/api/v1/market/data/ths-concept-daily-flow"
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    base_parsed = urllib.parse.urlparse(BASE_URL)
+    if parsed.scheme != base_parsed.scheme or parsed.netloc != base_parsed.netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(req_or_url, urllib.request.Request):
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    if isinstance(req_or_url, urllib.request.Request):
+        for key, value in _REQUEST_HEADERS.items():
+            req_or_url.add_unredirected_header(key, value)
+    else:
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def build_params(args):
     params = {}
-    if args.start_date is not None: params["start_date"] = args.start_date
-    if args.end_date is not None: params["end_date"] = args.end_date
-    if args.sector_name is not None: params["sector_name"] = args.sector_name
-    if args.page is not None: params["page"] = args.page
-    if args.page_size is not None: params["page_size"] = args.page_size
-    if args.total is not None: params["total"] = args.total
-    if args.sector_name is not None: params["sector_name"] = args.sector_name
-    if args.trade_date is not None: params["trade_date"] = args.trade_date
-    if args.sector_index is not None: params["sector_index"] = args.sector_index
-    if args.change_pct is not None: params["change_pct"] = args.change_pct
-    if args.company_count is not None: params["company_count"] = args.company_count
-    if args.inflow is not None: params["inflow"] = args.inflow
-    if args.outflow is not None: params["outflow"] = args.outflow
-    if args.net_amount is not None: params["net_amount"] = args.net_amount
-    if args.leader_name is not None: params["leader_name"] = args.leader_name
-    if args.leader_change_pct is not None: params["leader_change_pct"] = args.leader_change_pct
-    if args.leader_price is not None: params["leader_price"] = args.leader_price
+    if args.start_date is not None:
+        params["start_date"] = args.start_date
+    if args.end_date is not None:
+        params["end_date"] = args.end_date
+    if args.board_name is not None:
+        params["board_name"] = args.board_name
+    if args.page is not None:
+        params["page"] = args.page
+    if args.page_size is not None:
+        params["page_size"] = args.page_size
+    return params
+
+
+def fetch(params):
     query = ("?" + urllib.parse.urlencode(params)) if params else ""
-    request = urllib.request.Request(BASE_URL + ENDPOINT + query, headers={**_REQUEST_HEADERS, "FTSHARE_API_KEY": key, "Content-Type": "application/json", "X-Client-Name": "ft-claw"}, method="GET")
+    req = urllib.request.Request(
+        f"{BASE_URL}{ENDPOINT}{query}",
+        headers={**HEADERS, **_REQUEST_HEADERS},
+        method="GET",
+    )
     try:
-        with safe_urlopen(request) as response: payload = json.loads(response.read().decode())
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
-    except urllib.error.HTTPError as error:
-        print(f"HTTP {error.code}: {error.read().decode()}", file=sys.stderr); raise SystemExit(1)
-    except urllib.error.URLError as error:
-        print(f"请求失败: {error.reason}", file=sys.stderr); raise SystemExit(1)
-if __name__ == "__main__": main()
+        with safe_urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    _require_api_key()
+    parser = argparse.ArgumentParser(description="同花顺概念板块资金流日度")
+    parser.add_argument("--start-date", dest="start_date", default=None, help="开始日期 YYYYMMDD")
+    parser.add_argument("--end-date", dest="end_date", default=None, help="结束日期 YYYYMMDD")
+    parser.add_argument("--board-name", dest="board_name", default=None,
+                        help="概念板块名称，精确匹配，如 机器人概念；不传返回全部概念板块")
+    parser.add_argument("--page", type=int, default=None, help="页码")
+    parser.add_argument("--page-size", dest="page_size", type=int, default=None, help="每页条数")
+    args = parser.parse_args()
+
+    print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ftshare-market-data/sub-skills/ths-concept-daily-flow/scripts/test_handler.py
+++ b/ftshare-market-data/sub-skills/ths-concept-daily-flow/scripts/test_handler.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Tests for ths-concept-daily-flow handler (board_name parameter rename)"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import importlib.util
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("handler", os.path.join(_dir, "handler.py"))
+handler = importlib.util.module_from_spec(spec)
+
+
+def _run(argv):
+    with patch.dict(os.environ, {"FTSHARE_API_KEY": "test-key"}):
+        with patch.object(sys, "argv", ["handler.py"] + argv):
+            handler.main()
+
+
+class TestBoardName(unittest.TestCase):
+    def setUp(self):
+        spec.loader.exec_module(handler)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_board_name_sent(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run(["--start-date", "20260805", "--end-date", "20260805",
+              "--board-name", "机器人概念", "--page", "1", "--page-size", "100"])
+        req = mock_open.call_args[0][0]
+        self.assertIn("/api/v1/market/data/ths-concept-daily-flow", req.full_url)
+        self.assertIn("board_name=%E6%9C%BA%E5%99%A8%E4%BA%BA%E6%A6%82%E5%BF%B5", req.full_url)
+        self.assertNotIn("sector_name", req.full_url)
+        self.assertNotIn("trade_date", req.full_url)
+
+    @patch.object(handler, "safe_urlopen")
+    def test_all_params_optional(self, mock_open):
+        mock_open.return_value.__enter__.return_value.read.return_value = b"{}"
+        _run([])
+        req = mock_open.call_args[0][0]
+        self.assertTrue(req.full_url.endswith("/api/v1/market/data/ths-concept-daily-flow"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ftshare-market-data/sub-skills/ths-industry-daily-flow/SKILL.md
+++ b/ftshare-market-data/sub-skills/ths-industry-daily-flow/SKILL.md
@@ -1,16 +1,44 @@
 ---
 name: ths-industry-daily-flow
-description: 查询同花顺行业板块资金流日度。接口：GET /api/v1/market/data/ths-industry-daily-flow。所有请求必须设置 FTSHARE_API_KEY。
+description: 查询同花顺行业板块资金流日度。用户问同花顺行业板块资金流、行业板块每日净流入、行业资金流向、领涨股涨跌幅时使用。
 ---
 
 # 同花顺行业板块资金流日度
 
-接口：GET `/api/v1/market/data/ths-industry-daily-flow`。参数和响应以 `ftshare-doc/api-doc/股票数据/资金流向数据/同花顺行业板块资金流日度.md` 为准。
+## 1. 接口描述
 
-请求必须从环境变量 `FTSHARE_API_KEY` 读取凭据，并通过请求头发送 `FTSHARE_API_KEY` 和 `Content-Type: application/json`；缺少凭据时不会发起请求。
+| 项目 | 说明 |
+|------|------|
+| 接口名称 | 同花顺行业板块资金流日度 |
+| 外部接口 | `GET /api/v1/market/data/ths-industry-daily-flow` |
+| 请求方式 | GET（query 参数） |
+| 适用场景 | 按日期范围查询同花顺行业板块日度资金流，含板块指数、涨跌幅、流入/流出/净额、领涨股及涨跌幅 |
 
-## 调用示例
+## 2. 请求参数
+
+| 参数名 | 类型 | 是否必填 | 描述 | 取值示例 | 备注 |
+|--------|------|----------|------|----------|------|
+| start_date | string | 否 | 开始日期 | 20260805 | YYYYMMDD |
+| end_date | string | 否 | 结束日期 | 20260805 | YYYYMMDD |
+| board_name | string | 否 | 行业板块名称，精确匹配 | 证券 | 不能是空白字符串；不传返回日期范围内全部行业板块 |
+| page | int | 否 | 页码 | 1 | - |
+| page_size | int | 否 | 每页条数 | 100 | - |
+
+## 3. 响应说明
+
+返回分页结构。records 元素核心字段：`board_name`（行业板块名称）、`trade_date`、`board_index`（板块指数，可为 null）、`change_pct`、`company_count`、`inflow`、`outflow`、`net_amount`、`leader_name`、`leader_change_pct`、`leader_price`。
+
+## 4. 调用方式
 
 ```bash
-python <RUN_PY> ths-industry-daily-flow --start_date 20260828 --end_date 20260828 --page 1 --trade_date 20260828
+python <RUN_PY> ths-industry-daily-flow --start-date 20260805 --end-date 20260805 --board-name 证券 --page 1 --page-size 100
+python <RUN_PY> ths-industry-daily-flow --start-date 20260801 --end-date 20260805 --page 1 --page-size 100
 ```
+
+`<RUN_PY>` 为主 SKILL.md 同级 `run.py` 的绝对路径。输出 JSON；HTTP 错误输出到 stderr 并以非零状态退出。
+
+## 5. 注意事项
+
+- 板块名称参数为 `board_name`（原 `sector_name` 已更名，不再使用旧参数名），输出字段同步为 `board_name` / `board_index`。
+- 结果按 `trade_date` 降序、`board_name` 升序排列。
+- 源数据缺项返回 `null`，接口不做聚合、单位转换或缺失值补算。

--- a/ftshare-market-data/sub-skills/ths-industry-daily-flow/scripts/handler.py
+++ b/ftshare-market-data/sub-skills/ths-industry-daily-flow/scripts/handler.py
@@ -1,67 +1,99 @@
 #!/usr/bin/env python3
-import argparse, json, os, sys, urllib.error, urllib.parse, urllib.request
-BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
-ENDPOINT = '/api/v1/market/data/ths-industry-daily-flow'
-SAFE_URLOPENER = urllib.request.build_opener()
-_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+"""同花顺行业板块资金流日度（GET /api/v1/market/data/ths-industry-daily-flow）"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import os
+
 def _require_api_key():
     key = os.environ.get("FTSHARE_API_KEY")
     if not key:
-        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr); raise SystemExit(2)
+        print("FTSHARE_API_KEY environment variable is required", file=sys.stderr)
+        raise SystemExit(2)
     return key
-def safe_urlopen(request, timeout=30):
-    url = request.full_url if isinstance(request, urllib.request.Request) else str(request)
-    parsed, base = urllib.parse.urlparse(url), urllib.parse.urlparse(BASE_URL)
-    if parsed.scheme != base.scheme or parsed.netloc != base.netloc:
-        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr); raise SystemExit(1)
-    if not isinstance(request, urllib.request.Request): request = urllib.request.Request(url, method="GET")
-    request.add_unredirected_header("FTSHARE_API_KEY", _require_api_key())
-    request.add_unredirected_header("Content-Type", "application/json")
-    return SAFE_URLOPENER.open(request, timeout=timeout)
-def main():
-    key = _require_api_key(); parser = argparse.ArgumentParser(description='同花顺行业板块资金流日度')
-    parser.add_argument("--start_date", required=True)
-    parser.add_argument("--end_date", required=True)
-    parser.add_argument("--sector_name")
-    parser.add_argument("--page")
-    parser.add_argument("--page_size")
-    parser.add_argument("--total", required=False)
-    parser.add_argument("--trade_date", required=True)
-    parser.add_argument("--sector_index", required=False)
-    parser.add_argument("--change_pct", required=False)
-    parser.add_argument("--company_count", required=False)
-    parser.add_argument("--inflow", required=False)
-    parser.add_argument("--outflow", required=False)
-    parser.add_argument("--net_amount", required=False)
-    parser.add_argument("--leader_name", required=False)
-    parser.add_argument("--leader_change_pct", required=False)
-    parser.add_argument("--leader_price", required=False)
-    args = parser.parse_args()
+
+
+SAFE_URLOPENER = urllib.request.build_opener()
+
+BASE_URL = os.environ.get("FTSHARE_BASE_URL", "https://market.ft.tech/gateway").rstrip("/")
+_REQUEST_HEADERS = {"FTSHARE_API_KEY": os.environ["FTSHARE_API_KEY"], "Content-Type": "application/json"} if os.environ.get("FTSHARE_API_KEY") else {}
+ENDPOINT = "/api/v1/market/data/ths-industry-daily-flow"
+
+HEADERS = {
+    "X-Client-Name": "ft-claw",
+    "Content-Type": "application/json",
+}
+
+
+def safe_urlopen(req_or_url):
+    if isinstance(req_or_url, urllib.request.Request):
+        url = req_or_url.full_url
+    else:
+        url = str(req_or_url)
+    parsed = urllib.parse.urlparse(url)
+    base_parsed = urllib.parse.urlparse(BASE_URL)
+    if parsed.scheme != base_parsed.scheme or parsed.netloc != base_parsed.netloc:
+        print(f"Invalid URL for safe_urlopen: {url}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(req_or_url, urllib.request.Request):
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    if isinstance(req_or_url, urllib.request.Request):
+        for key, value in _REQUEST_HEADERS.items():
+            req_or_url.add_unredirected_header(key, value)
+    else:
+        req_or_url = urllib.request.Request(str(req_or_url), headers=_REQUEST_HEADERS, method="GET")
+    return SAFE_URLOPENER.open(req_or_url)
+
+
+def build_params(args):
     params = {}
-    if args.start_date is not None: params["start_date"] = args.start_date
-    if args.end_date is not None: params["end_date"] = args.end_date
-    if args.sector_name is not None: params["sector_name"] = args.sector_name
-    if args.page is not None: params["page"] = args.page
-    if args.page_size is not None: params["page_size"] = args.page_size
-    if args.total is not None: params["total"] = args.total
-    if args.sector_name is not None: params["sector_name"] = args.sector_name
-    if args.trade_date is not None: params["trade_date"] = args.trade_date
-    if args.sector_index is not None: params["sector_index"] = args.sector_index
-    if args.change_pct is not None: params["change_pct"] = args.change_pct
-    if args.company_count is not None: params["company_count"] = args.company_count
-    if args.inflow is not None: params["inflow"] = args.inflow
-    if args.outflow is not None: params["outflow"] = args.outflow
-    if args.net_amount is not None: params["net_amount"] = args.net_amount
-    if args.leader_name is not None: params["leader_name"] = args.leader_name
-    if args.leader_change_pct is not None: params["leader_change_pct"] = args.leader_change_pct
-    if args.leader_price is not None: params["leader_price"] = args.leader_price
+    if args.start_date is not None:
+        params["start_date"] = args.start_date
+    if args.end_date is not None:
+        params["end_date"] = args.end_date
+    if args.board_name is not None:
+        params["board_name"] = args.board_name
+    if args.page is not None:
+        params["page"] = args.page
+    if args.page_size is not None:
+        params["page_size"] = args.page_size
+    return params
+
+
+def fetch(params):
     query = ("?" + urllib.parse.urlencode(params)) if params else ""
-    request = urllib.request.Request(BASE_URL + ENDPOINT + query, headers={**_REQUEST_HEADERS, "FTSHARE_API_KEY": key, "Content-Type": "application/json", "X-Client-Name": "ft-claw"}, method="GET")
+    req = urllib.request.Request(
+        f"{BASE_URL}{ENDPOINT}{query}",
+        headers={**HEADERS, **_REQUEST_HEADERS},
+        method="GET",
+    )
     try:
-        with safe_urlopen(request) as response: payload = json.loads(response.read().decode())
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
-    except urllib.error.HTTPError as error:
-        print(f"HTTP {error.code}: {error.read().decode()}", file=sys.stderr); raise SystemExit(1)
-    except urllib.error.URLError as error:
-        print(f"请求失败: {error.reason}", file=sys.stderr); raise SystemExit(1)
-if __name__ == "__main__": main()
+        with safe_urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    _require_api_key()
+    parser = argparse.ArgumentParser(description="同花顺行业板块资金流日度")
+    parser.add_argument("--start-date", dest="start_date", default=None, help="开始日期 YYYYMMDD")
+    parser.add_argument("--end-date", dest="end_date", default=None, help="结束日期 YYYYMMDD")
+    parser.add_argument("--board-name", dest="board_name", default=None,
+                        help="行业板块名称，精确匹配，如 证券；不传返回全部行业板块")
+    parser.add_argument("--page", type=int, default=None, help="页码")
+    parser.add_argument("--page-size", dest="page_size", type=int, default=None, help="每页条数")
+    args = parser.parse_args()
+
+    print(json.dumps(fetch(build_params(args)), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 新增子 skill：etf-pcf-infos、etf-share、etf-net-value、etf-announcements、etf-component-details、stock-dividends-effective、index-candlesticks-batch、etf-candlesticks-batch、futures-contract-kline
- 批量 K 线对齐 v2 契约：since_ts_millis 必填（跨度≤12 个日历月）、移除 Minute/interval_value、响应统一短后缀、补充 turnover_rate 字段
- 板块资金流参数更名：东方财富 sector_code/sector_type/sector_level → board_code/board_type/board_level，同花顺 sector_name → board_name（输出字段同步更名）
- 股票 K 线、批量 K 线、历史/实时分钟与日 K 线文档补充 turnover_rate 输出字段
- 修正示例：futures-settle 补必填 --exchange，stock-minutes-batch 改用股票标的与交易日分钟戳，stock-history-list、stock-announcements 改用有效交易日
- 根 SKILL.md 与 README 同步路由、示例与能力总览
- 融资融券明细新增时间范围查询